### PR TITLE
Update rpcmining.cpp

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -503,7 +503,7 @@ Value getblocktemplate(const Array& params, bool fHelp)
         uint256 txHash = tx.GetHash();
         setTxIndex[txHash] = i++;
 
-        if (tx.IsCoinBase() || tx.IsZerocoinSpend())
+        if (tx.IsCoinBase())
             continue;
 
         Object entry;


### PR DESCRIPTION
Fixed problem zerocoin spend doesn't include in block when mining with pool