### PR TITLE
[FIX] miniupnpc compilation issue

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1087,7 +1087,12 @@ void ThreadMapPort()
     int error = 0;
     // remove the 2 if you have trouble compiling - I had to add it for miniupnpc 2.0
     //devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
+#if MINIUPNPC_API_VERSION > 13
+    unsigned char ttl = 2;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, ttl, &error);
+#else
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#endif
 #endif
 
     struct UPNPUrls urls;


### PR DESCRIPTION
This fixes the compilation issue with various miniupnpc version across
various systems. The patch is adapted from what was used in the Monero
project here: https://github.com/monero-project/monero/pull/422/files