### PR TITLE
Build for ARM64

### DIFF
--- a/src/Lyra2Z/sph_types.h
+++ b/src/Lyra2Z/sph_types.h
@@ -1053,7 +1053,7 @@ typedef long long sph_s64;
 /*
  * ARM, little-endian.
  */
-#elif defined __arm__ && __ARMEL__
+#elif defined __arm__ && __ARMEL__ || __AARCH64EL__
 
 #define SPH_DETECT_LITTLE_ENDIAN     1
 

--- a/src/leveldb/port/atomic_pointer.h
+++ b/src/leveldb/port/atomic_pointer.h
@@ -97,14 +97,13 @@ inline void MemoryBarrier() {
 
 // ARM64 Linux
 #elif defined(ARCH_CPU_A64_FAMILY) && defined(__linux__)
-typedef void (*LinuxKernelMemoryBarrierFunc)(void);
 // With more affordable 64-bit ARM devices available in the market, it becomes
 // hard to expect device-specific memory barrier function universally available
 // in ARM64 kernel.
 //
 // Some device vendors completely omitted, and made regression to compiler
-// memory barrier. Few device vendors went out implementing the function With
-// CPU-specific instructions. Even from vendor to vendor, the used instructions
+// memory barrier. Few device vendors went out implementing the function with
+// CPU-specific instructions. Even from vendor to vendor, used instructions
 // are different, and one cannot expect unified ground like it is available in
 // 32-bit ARM device landscape.
 //

--- a/src/leveldb/port/atomic_pointer.h
+++ b/src/leveldb/port/atomic_pointer.h
@@ -34,7 +34,7 @@
 #define ARCH_CPU_X86_FAMILY 1
 #elif defined(_M_IX86) || defined(__i386__) || defined(__i386)
 #define ARCH_CPU_X86_FAMILY 1
-#elif defined(__ARMEL__)
+#elif defined(__ARMEL__) || defined(__AARCH64EL__)
 #define ARCH_CPU_ARM_FAMILY 1
 #elif defined(__ppc__) || defined(__powerpc__) || defined(__powerpc64__)
 #define ARCH_CPU_PPC_FAMILY 1

--- a/src/leveldb/port/atomic_pointer.h
+++ b/src/leveldb/port/atomic_pointer.h
@@ -34,8 +34,10 @@
 #define ARCH_CPU_X86_FAMILY 1
 #elif defined(_M_IX86) || defined(__i386__) || defined(__i386)
 #define ARCH_CPU_X86_FAMILY 1
-#elif defined(__ARMEL__) || defined(__AARCH64EL__)
+#elif defined(__ARMEL__)
 #define ARCH_CPU_ARM_FAMILY 1
+#elif defined(__AARCH64EL__)
+#define ARCH_CPU_A64_FAMILY 1
 #elif defined(__ppc__) || defined(__powerpc__) || defined(__powerpc64__)
 #define ARCH_CPU_PPC_FAMILY 1
 #endif
@@ -90,6 +92,30 @@ typedef void (*LinuxKernelMemoryBarrierFunc)(void);
 //
 inline void MemoryBarrier() {
   (*(LinuxKernelMemoryBarrierFunc)0xffff0fa0)();
+}
+#define LEVELDB_HAVE_MEMORY_BARRIER
+
+// ARM64 Linux
+#elif defined(ARCH_CPU_A64_FAMILY) && defined(__linux__)
+typedef void (*LinuxKernelMemoryBarrierFunc)(void);
+// With more affordable 64-bit ARM devices available in the market, it becomes
+// hard to expect device-specific memory barrier function universally available
+// in ARM64 kernel.
+//
+// Some device vendors completely omitted, and made regression to compiler
+// memory barrier. Few device vendors went out implementing the function With
+// CPU-specific instructions. Even from vendor to vendor, the used instructions
+// are different, and one cannot expect unified ground like it is available in
+// 32-bit ARM device landscape.
+//
+// A common trick used by aforementioned device vendors as well as for other
+// architectures is brought here that one can expect maximum compatibility
+// across various ARM64 devices. It also implies that there is a room for
+// improvment in the future as market matures and more device vendors provide
+// performant device-specific memory barrier functions in the kernel.
+//
+inline void MemoryBarrier() {
+  asm volatile ("": : :"memory");
 }
 #define LEVELDB_HAVE_MEMORY_BARRIER
 
@@ -216,6 +242,7 @@ class AtomicPointer {
 #undef LEVELDB_HAVE_MEMORY_BARRIER
 #undef ARCH_CPU_X86_FAMILY
 #undef ARCH_CPU_ARM_FAMILY
+#undef ARCH_CPU_A64_FAMILY
 #undef ARCH_CPU_PPC_FAMILY
 
 }  // namespace port


### PR DESCRIPTION
Building Zcoin daemon for ARM64 on Ubuntu 16.04 with GCC 5.4 yield a compiler error. [`Please implement AtomicPointer for this platform`](https://github.com/zcoinofficial/zcoin/blob/master/src/leveldb/port/atomic_pointer.h#L212). This indicates that neither GCC 5.4 for ARM64 has cstdatomic support, nor `atomic_pointer.h` has an appropriate arch section for ARM64.

To remedy the error, two places are patched.

1. **`Lyra2Z/sph_types.h`**
  - ARM64's instruction set only handles little-endian (could handle big-endien data though).  
2. **`leveldb/port/atomic_pointer.h`**
  - GCC 5 has `__AARCH64EL__` definition for ARM64 which is missing in the header and causes the compiler to complain. `ARCH_CPU_A64_FAMILY` is added to support ARM64.
  - ARM64 memory barrier function isn't universally available so `asm volatile` is deployed.

Please review and modify as it fits.