### PR TITLE
fix a couple of 'unused variable' compile warnings

### DIFF
--- a/src/definition.h
+++ b/src/definition.h
@@ -14,7 +14,7 @@ enum {
     BLOCK_VERSION_CHAIN_START = (1 << 16),
     BLOCK_VERSION_CHAIN_END = (1 << 30),
 };
-static int64_t nStartRewardTime = 1475020800;
+static const int64_t nStartRewardTime = 1475020800;
 
 #endif //BTZC_DEFINITION_H
 

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -382,7 +382,7 @@ void CBlockPolicyEstimator::processTransaction(const CTxMemPoolEntry& entry, boo
     // Want the priority of the tx at confirmation. However we don't know
     // what that will be and its too hard to continue updating it
     // so use starting priority as a proxy
-    double curPri = entry.GetPriority(txHeight);
+//    double curPri = entry.GetPriority(txHeight);
     mapMemPoolTxs[hash].blockHeight = txHeight;
 
     LogPrint("estimatefee", "Blockpolicy mempool tx %s \n", hash.ToString());


### PR DESCRIPTION
definition: made nStartRewardTime const
policy/fees: commented out line with unused var curPri
commented and did not delete as looks like others are working in there 