### PR TITLE
fix typo in zcoin-cli znode help command

### DIFF
--- a/src/rpc/rpcznode.cpp
+++ b/src/rpc/rpcznode.cpp
@@ -460,7 +460,7 @@ UniValue znodelist(const UniValue &params, bool fHelp) {
                         "  lastpaidblock  - Print the last block height a node was paid on the network\n"
                         "  lastpaidtime   - Print the last time a node was paid on the network\n"
                         "  lastseen       - Print timestamp of when a znode was last seen on the network\n"
-                        "  payee          - Print Dash address associated with a znode (can be additionally filtered,\n"
+                        "  payee          - Print Zcoin address associated with a znode (can be additionally filtered,\n"
                         "                   partial match)\n"
                         "  protocol       - Print protocol of a znode (can be additionally filtered, exact match))\n"
                         "  rank           - Print rank of a znode based on current block\n"

--- a/src/rpc/rpcznode.cpp
+++ b/src/rpc/rpcznode.cpp
@@ -112,7 +112,7 @@ UniValue znode(const UniValue &params, bool fHelp) {
                         "  debug        - Print znode status\n"
                         "  genkey       - Generate new znodeprivkey\n"
                         "  outputs      - Print znode compatible outputs\n"
-                        "  start        - Start local Hot znode configured in dash.conf\n"
+                        "  start        - Start local Hot znode configured in znode.conf\n"
                         "  start-alias  - Start single remote znode by assigned alias configured in znode.conf\n"
                         "  start-<mode> - Start remote znodes configured in znode.conf (<mode>: 'all', 'missing', 'disabled')\n"
                         "  status       - Print znode status information\n"


### PR DESCRIPTION
Just a trivial typo fix.