### PR TITLE
Add a mutex lock to protect CNode::nRefCount

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -469,6 +469,8 @@ private:
     static uint64_t nMaxOutboundLimit;
     static uint64_t nMaxOutboundTimeframe;
 
+    CCriticalSection cs_nRefCount;
+
     CNode(const CNode&);
     void operator=(const CNode&);
 
@@ -482,6 +484,7 @@ public:
 
     int GetRefCount()
     {
+        LOCK(cs_nRefCount);
         assert(nRefCount >= 0);
         return nRefCount;
     }
@@ -508,12 +511,14 @@ public:
 
     CNode* AddRef()
     {
+        LOCK(cs_nRefCount);
         nRefCount++;
         return this;
     }
 
     void Release()
     {
+        LOCK(cs_nRefCount);
         nRefCount--;
     }
 


### PR DESCRIPTION
This should fix #169 - partial backport of https://github.com/dashpay/dash/pull/1321

On Linux this crash happens as well, error message

```
zcoind: net.h:485: int CNode::GetRefCount(): Assertion `nRefCount >= 0' failed.
```

stack trace looks like this

```
Program terminated with signal SIGABRT, Aborted.
#0  0x00007f7f50156c37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
56    ../nptl/sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  0x00007f7f50156c37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007f7f5015a028 in __GI_abort () at abort.c:89
#2  0x00007f7f5014fbf6 in __assert_fail_base (fmt=0x7f7f502a4058 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=assertion@entry=0x5618cc0467a3 "nRefCount >= 0", file=file@entry=0x5618cc04679d "net.h",
    line=line@entry=485, function=function@entry=0x5618cc050bd0 "int CNode::GetRefCount()") at assert.c:92
#3  0x00007f7f5014fca2 in __GI___assert_fail (assertion=0x5618cc0467a3 "nRefCount >= 0", file=0x5618cc04679d "net.h", line=485, function=0x5618cc050bd0 "int CNode::GetRefCount()") at assert.c:101
```