### PR TITLE
fixed build system/gitian builds

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-DIST_SUBDIRS = secp256k1 univalue
+DIST_SUBDIRS = secp256k1 univalue tor
 SUBDIRS = tor
 
 AM_LDFLAGS = $(PTHREAD_CFLAGS) $(LIBTOOL_LDFLAGS) $(HARDENED_LDFLAGS)
@@ -367,8 +367,6 @@ libbitcoin_util_a_SOURCES = \
   utiltime.cpp \
   crypto/scrypt.cpp \
   primitives/block.cpp \
-  libexecstream/exec-stream.h \
-  libexecstream/exec-stream.cpp \
   libzerocoin/bitcoin_bignum/allocators.h \
   libzerocoin/bitcoin_bignum/bignum.h \
   libzerocoin/bitcoin_bignum/compat.h \

--- a/src/tor/src/ext/include.am
+++ b/src/tor/src/ext/include.am
@@ -170,7 +170,6 @@ EXTRA_DIST += \
 	src/ext/timeouts/bench/Rules.mk			\
 	src/ext/timeouts/lua/Rules.mk			\
 	src/ext/timeouts/lua/timeout-lua.c		\
-	src/ext/timeouts/Makefile			\
 	src/ext/timeouts/Rules.shrc			\
 	src/ext/timeouts/test-timeout.c
 


### PR DESCRIPTION
The build system is broken in Zcoin 0.13.5 - this fixes it and also re-enables Gitian builds.