### PR TITLE
Change confusing wording of error message

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3696,7 +3696,7 @@ bool CWallet::CreateZerocoinSpendTransaction(int64_t nValue, libzerocoin::CoinDe
             }
 
             if (coinId == INT_MAX){
-                strFailReason = _("it has to have at least two mint coins with at least 6 confirmation in order to spend a coin");
+                strFailReason = _("either your mint does not have 6 confirmations yet or nobody else has minted this denomination, which could compromise your anonymity");
                 return false;
             }
 


### PR DESCRIPTION
Existing error message "[...] it has to have at least two mint coins with at least 6 confirmation in order to spend a coin" is confusing to many users. 

"What does this mean?", "Do I have to create two mints in order to do one spend?", "What does 'it' refer to?" etc. were common questions. 

Hoping to provide a clearer error message here.