### PR TITLE
Separation of Znode and Wallet libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,11 +92,7 @@ AC_PATH_TOOL(OBJCOPY, objcopy)
 AC_ARG_VAR(PYTHONPATH, Augments the default search path for python module files)
 
 # Enable wallet
-AC_ARG_ENABLE([wallet],
-  [AS_HELP_STRING([--disable-wallet],
-  [disable wallet (enabled by default)])],
-  [enable_wallet=$enableval],
-  [enable_wallet=yes])
+enable_wallet=yes
 
 AC_ARG_WITH([miniupnpc],
   [AS_HELP_STRING([--with-miniupnpc],


### PR DESCRIPTION
Currently the code for Znode's depends on Wallet functionality being enabled; As a result, passing the `disable-wallet` flag to `configure` will cause the build to fail outright (see https://github.com/zcoinofficial/zcoin/issues/204).
Myself and @devwarrior777 propose a two step process forward:

(1) initially disable the `disable-wallet` option; this will ensure building regardless of flags passed to configure
(2) work towards separation of Znode functionality into a separate library

Part (1) is contained in this pull request.