### PR TITLE
Allow znode to run on any port.

### DIFF
--- a/src/znodeconfig.cpp
+++ b/src/znodeconfig.cpp
@@ -68,23 +68,6 @@ bool CZnodeConfig::read(std::string& strErr) {
         LogPrintf("mainnetDefaultPort=%s\n", mainnetDefaultPort);
         LogPrintf("Params().NetworkIDString()=%s\n", Params().NetworkIDString());
         LogPrintf("CBaseChainParams::MAIN=%s\n", CBaseChainParams::MAIN);
-        if(Params().NetworkIDString() == CBaseChainParams::MAIN) {
-            if(port != mainnetDefaultPort) {
-                strErr = _("Invalid port detected in znode.conf") + "\n" +
-                        strprintf(_("Port: %d"), port) + "\n" +
-                        strprintf(_("Line: %d"), linenumber) + "\n\"" + line + "\"" + "\n" +
-                        strprintf(_("(must be %d for mainnet)"), mainnetDefaultPort);
-                streamConfig.close();
-                return false;
-            }
-        } else if(port == mainnetDefaultPort) {
-            strErr = _("Invalid port detected in znode.conf") + "\n" +
-                    strprintf(_("Line: %d"), linenumber) + "\n\"" + line + "\"" + "\n" +
-                    strprintf(_("(%d could be used only on mainnet)"), mainnetDefaultPort);
-            streamConfig.close();
-            return false;
-        }
-
 
         add(alias, ip, privKey, txHash, outputIndex);
     }


### PR DESCRIPTION
Currently there's a requirement that znodes run on the same port (8168).
However, there are 2 major issues with this:

 - the network is susceptible to an attack where an ISP or other
   provider could simply block port 8168, breaking all znodes
 - it's impossible to run multiple znodes with the same IP, which is
   largely an artificial limitation