### PR TITLE
RPC additions and updates

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -115,6 +115,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
         //[zcoin]
     { "setmininput", 0 },
     { "mintzerocoin", 0 },
+    { "mintmanyzerocoin", 0 },
     { "spendzerocoin", 0 },
     { "spendmanyzerocoin", 0 },
     { "setgenerate", 0 },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -116,6 +116,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "setmininput", 0 },
     { "mintzerocoin", 0 },
     { "spendzerocoin", 0 },
+    { "spendmanyzerocoin", 0 },
     { "setgenerate", 0 },
     { "setgenerate", 1 },
     { "setmintzerocoinstatus", 2 },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -21,6 +21,8 @@
 #include "walletdb.h"
 #include "zerocoin.h"
 
+#include <znode-payments.h>
+
 #include <stdint.h>
 
 #include <boost/assign/list_of.hpp>
@@ -1392,7 +1394,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                  
                     CTxDestination payeeDest;
                     ExtractDestination(payee, payeeDest);
-                    CBitcoinAddress payeeAddr(payee_dest);
+                    CBitcoinAddress payeeAddr(payeeDest);
 
                     //compare address of payee and addr.
                     if(addr.ToString() == payeeAddr.ToString()){

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2776,7 +2776,7 @@ UniValue mintmanyzerocoin(const UniValue& params, bool fHelp)
                 break;
             default:
                 throw runtime_error(
-                    "mintzerocoin <amount>(1,10,25,50,100) (\"zcoinaddress\")\n");
+                    "mintmanyzerocoin <amount>(1,10,25,50,100) (\"zcoinaddress\")\n");
         }
 
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1358,7 +1358,15 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                 entry.push_back(Pair("involvesWatchonly", true));
             entry.push_back(Pair("account", strSentAccount));
             MaybePushAddress(entry, s.destination, addr);
-            entry.push_back(Pair("category", "send"));
+            if(wtx.IsZerocoinMint(wtx)){
+                    entry.push_back(Pair("category", "mint"));
+                }
+            else if(wtx.IsZerocoinSpend()){
+                    entry.push_back(Pair("category", "spend"));
+                }
+            else {
+                entry.push_back(Pair("category", "send"));
+            }
             entry.push_back(Pair("amount", ValueFromAmount(-s.amount)));
             if (pwalletMain->mapAddressBook.count(s.destination))
                 entry.push_back(Pair("label", pwalletMain->mapAddressBook[s.destination].name));
@@ -1390,13 +1398,12 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                 {
                     int txHeight = chainActive.Height() - wtx.GetDepthInMainChain();
                     CScript payee;
+
                     mnpayments.GetBlockPayee(txHeight, payee);
-                 
+                    //compare address of payee to addr. 
                     CTxDestination payeeDest;
                     ExtractDestination(payee, payeeDest);
                     CBitcoinAddress payeeAddr(payeeDest);
-
-                    //compare address of payee and addr.
                     if(addr.ToString() == payeeAddr.ToString()){
                         entry.push_back(Pair("category", "znode"));
                     }
@@ -1407,14 +1414,10 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                     else
                         entry.push_back(Pair("category", "generate"));
                 }
-                else if(wtx.IsZerocoinMint(wtx)){
-                    entry.push_back(Pair("category", "mint"));
-                }
                 else if(wtx.IsZerocoinSpend()){
                     entry.push_back(Pair("category", "spend"));
                 }
-                else
-                {
+                else {
                     entry.push_back(Pair("category", "receive"));
                 }
                 entry.push_back(Pair("amount", ValueFromAmount(r.amount)));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3929,10 +3929,6 @@ bool CWallet::CommitZerocoinSpendTransaction(CWalletTx &wtxNew, CReserveKey &res
  * @return
  */
 string CWallet::MintZerocoin(CScript pubCoin, int64_t nValue, CWalletTx &wtxNew, bool fAskFee) {
-    // Do not allow mint to take place until fully synced
-    // Temporary measure: we can remove this limitation when well after spend v1.5 HF block
-    if (fImporting || fReindex || !znodeSync.IsBlockchainSynced())
-        return _("Not fully synced yet");
 
     LogPrintf("MintZerocoin: value = %s\n", nValue);
     // Check amount
@@ -3996,12 +3992,6 @@ string CWallet::SpendZerocoin(std::string &thirdPartyaddress, int64_t nValue, li
     // Check amount
     if (nValue <= 0)
         return _("Invalid amount");
-
-    // Do not allow spend to take place until fully synced
-    // Temporary measure: we can remove this limitation when well after spend v1.5 HF block
-    if (fImporting || fReindex || !znodeSync.IsBlockchainSynced())
-        return _("Not fully synced yet");
-
 
     CReserveKey reservekey(this);
 


### PR DESCRIPTION
## Added spendmanyzerocoin RPC command

this RPC command allows the user to specify multiple addresses and denominations to spend. If the user wishes to make 1 or more spends to themselves, the address field is left blank. 
The number of spends to make to the address can also be specified.
For example, to spend 25 and 50 to two different third parties respectively:
```
spendmanyzerocoin "[{\"address\":\"TVyUgzLh1MCnjtwv3b4oCFB8STbpKPVSxu\",\"denomination\":25, \"amount\": 1},{\"address\":\"TY842FSFJH4TbFMXAdrgmb9XgDjfvJKqvc\",\"denomination\":50, \"amount\": 1}]"
```

or to spend 2 50's to a 3rd party, and 10 to yourself:
```
spendmanyzerocoin "[{\"address\":\"TWDwwUawEB5noiBuf8auamWPxouVeZn9hh\",\"denomination\":50, \"amount\": 2},{\"address\":\"\",\"denomination\":10, \"amount\": 1}]"
```
The function returns a list of the transaction IDs generated for the spends.

## Add mintmanyzerocoin RPC command

Along the same lines as `spendmanyzerocoin`, add a function that does several mints in a single call. the only parameter is a JSON object of the form `{<denomination>(1,10,25,50,100):amount,...}`, where `amount` is the number of mints to do for the `denomination` specified.
For example, to do 2 mints of denomination 10, and 5 mints of denomination 25:
```
mintmanyzerocoin "{\"10\":2,\"25\":5}"
```
The function returns the list of txids for the mints generated.

## Remove temporary sync block for zerocoin spend (for testnet usage)

The addition of the following into `wallet/wallet.cpp` makes the RPC spending functionality not work on testnet and regtest mode:
```
    // Do not allow mint to take place until fully synced
    // Temporary measure: we can remove this limitation when well after spend v1.5 HF block
    if (fImporting || fReindex || !znodeSync.IsBlockchainSynced())
        return _("Not fully synced yet");
``` 
As this was a temporary measure I propose we now remove this.

## Return txid instead of pubcoin after mint

currently the `mintzerocoin` RPC command returns the pubcoin that was generated from the mint. In line with other transaction-generating calls, I propose we instead return the transaction ID that the mint was contained within. The data related to the mint transaction can be returned following the `mintzerocoin` call in the `listmintzerocoins` function.

## Add znode, mint, and spend payment categories in ListTransactions
Add the ability to return whether or not this transaction is an incoming znode payment, a mint transaction, or a spend transaction in the `ListTransactions` RPC call in `wallet/rpcwallet.cpp`. This also means extending the `MaybePushAddress` function to take a pointer to a `CBitcoinAddress` instance.