### PR TITLE
Grammar #2

### DIFF
--- a/src/qt/zerocoinpage.cpp
+++ b/src/qt/zerocoinpage.cpp
@@ -120,7 +120,7 @@ void ZerocoinPage::on_zerocoinMintButton_clicked() {
                               QMessageBox::Ok, QMessageBox::Ok);
     }else{
     	QMessageBox::information(this, tr("Success"),
-    	                              tr("You have been successfully mint zerocoin from the wallet"),
+    	                              tr("Zerocoin successfully minted"),
     	                              QMessageBox::Ok, QMessageBox::Ok);
 
     }
@@ -148,7 +148,7 @@ void ZerocoinPage::on_zerocoinSpendButton_clicked() {
 								  QMessageBox::Ok, QMessageBox::Ok);
 		}else{
 			QMessageBox::information(this, tr("Success"),
-										  tr("You have been successfully spent zerocoin from the wallet"),
+										  tr("Zerocoin successfully spent"),
 										  QMessageBox::Ok, QMessageBox::Ok);
 
 		}


### PR DESCRIPTION
123: "You have been successfully mint zerocoin from the wallet" -> "Zerocoin successfully minted"
151: "You have been successfully spent zerocoin from the wallet" -> "Zerocoin successfully spent"

Please consider removing this message altogether. Result of mint can be seen immediately in minted coins list and the popup is not nice in terms of UX. Same with spend (status changes to "Used").