### PR TITLE
Grammar #3

### DIFF
--- a/src/qt/zerocoinpage.cpp
+++ b/src/qt/zerocoinpage.cpp
@@ -212,7 +212,7 @@ void ZerocoinPage::zerocoinSpendToMeCheckBoxChecked(int state) {
 
 void ZerocoinPage::on_exportButton_clicked() {
     // CSV is currently the only supported format
-    QString filename = GUIUtil::getSaveFileName(this, tr("Export Address List"), QString(), tr("Comma separated file (*.csv)"), NULL);
+    QString filename = GUIUtil::getSaveFileName(this, tr("Export Address List"), QString(), tr("Comma-separated file (*.csv)"), NULL);
 
     if (filename.isNull())
         return;


### PR DESCRIPTION
215: "Comma separated file (*.csv)" -> "Comma-separated file (*.csv)"

Compound modifiers need to be hyphenated