### PR TITLE
add reserved fields to future use

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -209,6 +209,9 @@ public:
     int32_t nVersionMTP = 0x1000;*/
     uint256 hashBlock;
 
+    uint256 hashReservedOne;
+    uint256 hashReservedTwo;
+
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     uint32_t nSequenceId;
 
@@ -255,6 +258,8 @@ public:
         	nProofMTP[i].clear();
         }*/
         hashBlock = uint256();
+        hashReservedOne = uint256();
+		hashReservedTwo = uint256();
 
         mintedPubCoins.clear();
         accumulatorChanges.clear();
@@ -275,6 +280,8 @@ public:
         nTime          = block.nTime;
         nBits          = block.nBits;
         hashBlock	   = block.GetHash();
+        hashReservedOne = block.hashReservedOne;
+		hashReservedTwo = block.hashReservedTwo;
         nNonce         = block.nNonce;
 
         // Zcoin - MTP
@@ -466,6 +473,8 @@ public:
         	}
         	//READWRITE(hashBlock);
         }*/
+        READWRITE(hashReservedOne);
+        READWRITE(hashReservedTwo);
 		READWRITE(hashBlock);
 
         if (!(nType & SER_GETHASH) && nVersion >= ZC_ADVANCED_INDEX_VERSION) {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -332,7 +332,7 @@ public:
         };
 
 	    nSpendV15StartBlock = ZC_V1_5_TESTNET_STARTING_BLOCK;
-        nCheckBugFixedAtBlock = 35000;
+        nCheckBugFixedAtBlock = ZC_CHECK_BUG_FIXED_AT_BLOCK;
 
 	    nSpendV2ID_1 = ZC_V2_TESTNET_SWITCH_ID_1;
 	    nSpendV2ID_10 = ZC_V2_TESTNET_SWITCH_ID_10;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -515,8 +515,11 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn)
 
         // Zcoin - MTP
         bool fMTPIsRequired = pblock->nTime >= Params().nMTPSwitchTime;
-        if (fMTPIsRequired)
+        if (fMTPIsRequired){
             pblock->mtpHashData = make_shared<CMTPHashData>();
+            pblock->hashReservedOne = uint256();
+            pblock->hashReservedTwo = uint256();
+        }
 
         pblocktemplate->vTxSigOpsCost[0] = GetLegacySigOpCount(pblock->vtx[0]);
 

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -115,11 +115,13 @@ void CBlockHeader::InvalidateCachedPoWHash(int nHeight) const {
 std::string CBlock::ToString() const {
     std::stringstream s;
     s << strprintf(
-            "CBlock(hash=%s, ver=0x%08x, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
+            "CBlock(hash=%s, ver=0x%08x, hashPrevBlock=%s, hashMerkleRoot=%s, hashReservedOne=%s, hashReservedTwo=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
             GetHash().ToString(),
             nVersion,
             hashPrevBlock.ToString(),
             hashMerkleRoot.ToString(),
+			hashReservedOne.ToString(),
+			hashReservedTwo.ToString(),
             nTime, nBits, nNonce,
             vtx.size());
     for (unsigned int i = 0; i < vtx.size(); i++) {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -97,6 +97,9 @@ public:
     // Store this only when absolutely needed for verification
     std::shared_ptr<CMTPHashData> mtpHashData;
 
+    uint256 hashReservedOne;
+    uint256 hashReservedTwo;
+
     static const int CURRENT_VERSION = 2;
 
     // uint32_t lastHeight;
@@ -133,6 +136,8 @@ public:
                 if (mtpHashData)
                     READWRITE(*mtpHashData);
             }
+            READWRITE(hashReservedOne);
+            READWRITE(hashReservedTwo);
         }
     }
 
@@ -147,6 +152,8 @@ public:
         if (IsMTP()) {
             READWRITE(nVersionMTP);
             READWRITE(hashRootMTP);
+            READWRITE(hashReservedOne);
+            READWRITE(hashReservedTwo);
         }
     }
 
@@ -164,6 +171,8 @@ public:
         // Zcoin - MTP
         mtpHashData.reset();
         memset(hashRootMTP, 0, sizeof(uint8_t)*16);
+        hashReservedOne.SetNull();
+        hashReservedTwo.SetNull();
     }
 
     int GetChainID() const

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -341,6 +341,8 @@ bool CBlockTreeDB::LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256
 
                 // Zcoin - MTP
                 pindexNew->hashBlock	  = diskindex.hashBlock;
+                pindexNew->hashReservedOne = diskindex.hashReservedOne;
+                pindexNew->hashReservedTwo = diskindex.hashReservedTwo;
 
                 /*
                 //if (!fTestNet && diskindex.nHeight >= HF_MTP_HEIGHT){


### PR DESCRIPTION
I added two fields of uint256 in blockheader for future using, with MTP transition, which will change the block header, it will be good time to add those fields. 