### PR TITLE
Minor bugfix for parameter reading in zcoind

### DIFF
--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -92,14 +92,14 @@ void SelectBaseParams(const std::string& chain)
 
 std::string ChainNameFromCommandLine()
 {
-    bool fRegTest = GetBoolArg("-regtest", false);
-    bool fTestNet = GetBoolArg("-testnet", true);
+    boost::optional<bool> regTest = GetOptBoolArg("-regtest")
+        , testNet = GetOptBoolArg("-testnet");
 
-    if (fTestNet && fRegTest)
+    if (testNet && regTest && testNet.get() && regTest.get())
         throw std::runtime_error("Invalid combination of -regtest and -testnet.");
-    if (fRegTest)
+    if (regTest && regTest.get())
         return CBaseChainParams::REGTEST;
-    if (fTestNet)
+    if (!testNet || testNet.get())
         return CBaseChainParams::TESTNET;
     return CBaseChainParams::MAIN;
 }

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -95,11 +95,11 @@ std::string ChainNameFromCommandLine()
     boost::optional<bool> regTest = GetOptBoolArg("-regtest")
         , testNet = GetOptBoolArg("-testnet");
 
-    if (testNet && regTest && testNet.get() && regTest.get())
+    if (testNet && regTest && *testNet && *regTest)
         throw std::runtime_error("Invalid combination of -regtest and -testnet.");
-    if (regTest && regTest.get())
+    if (regTest && *regTest)
         return CBaseChainParams::REGTEST;
-    if (!testNet || testNet.get())
+    if (!testNet || *testNet)
         return CBaseChainParams::TESTNET;
     return CBaseChainParams::MAIN;
 }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -442,7 +442,7 @@ UniValue CRPCTable::execute(const std::string &strMethod, const UniValue &params
     // Find method
     const CRPCCommand *pcmd = tableRPC[strMethod];
     if (!pcmd)
-        throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found: " + strMethod);
+        throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found");
 
     g_rpcSignals.PreCommand(*pcmd);
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -442,7 +442,7 @@ UniValue CRPCTable::execute(const std::string &strMethod, const UniValue &params
     // Find method
     const CRPCCommand *pcmd = tableRPC[strMethod];
     if (!pcmd)
-        throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found");
+        throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found: " + strMethod);
 
     g_rpcSignals.PreCommand(*pcmd);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -405,6 +405,17 @@ bool GetBoolArg(const std::string& strArg, bool fDefault)
     return fDefault;
 }
 
+boost::optional<bool> GetOptBoolArg(const std::string& strArg)
+{
+    auto const iter = mapArgs.find(strArg);
+    if(iter != mapArgs.end()){
+        if(iter->second.empty())
+            return boost::optional<bool>(true);
+        return boost::optional<bool>(InterpretBool(iter->second));
+    }
+    return boost::optional<bool>();
+}
+
 bool SoftSetArg(const std::string& strArg, const std::string& strValue)
 {
     if (mapArgs.count(strArg))

--- a/src/util.h
+++ b/src/util.h
@@ -29,6 +29,7 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/signals2/signal.hpp>
 #include <boost/thread/exceptions.hpp>
+#include <boost/optional.hpp>
 
 static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGIPS        = false;
@@ -183,6 +184,14 @@ int64_t GetArg(const std::string& strArg, int64_t nDefault);
  * @return command-line argument or default value
  */
 bool GetBoolArg(const std::string& strArg, bool fDefault);
+
+/**
+ * Return boost:optional<bool> for a specified argument
+ *
+ * @param strArg Argument to get (e.g. "-foo")
+ * @return command-line argument or default value
+ */
+boost::optional<bool> GetOptBoolArg(const std::string& strArg);
 
 /**
  * Set an argument if it doesn't already have a value


### PR DESCRIPTION
The bitcore-node-zcoin tests (and probably other tests) execute zcoind like this "zcoind --regtest". 
With the previous code:
```
bool fRegTest = GetBoolArg("-regtest", false);
bool fTestNet = GetBoolArg("-testnet", true);
if (fTestNet && fRegTest)
throw..
```
the exception was thrown. 