### PR TITLE
Repairing auto tests for bitcore-node-zcoin and zcoin-lib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,7 +113,7 @@ AC_ARG_ENABLE([upnp-default],
 AC_ARG_ENABLE(tests,
     AS_HELP_STRING([--disable-tests],[do not compile tests (default is to compile)]),
     [use_tests=$enableval],
-    [use_tests=no])
+    [use_tests=yes])
 
 AC_ARG_ENABLE(gui-tests,
     AS_HELP_STRING([--disable-gui-tests],[do not compile GUI tests (default is to compile if GUI and tests enabled)]),

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -94,7 +94,8 @@ BITCOIN_TESTS =\
   test/uint256_tests.cpp \
   test/univalue_tests.cpp \
   test/util_tests.cpp \
-  test/mtp_hash_validate_tests.cpp
+  test/mtp_hash_validate_tests.cpp \
+  test/chainparams_tests.cpp
 
 if ENABLE_WALLET
 BITCOIN_TESTS += \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -161,8 +161,8 @@ public:
         extraNonce[2] = 0x00;
         extraNonce[3] = 0x00;
         genesis = CreateGenesisBlock(ZC_GENESIS_BLOCK_TIME, 142392, 0x1e0ffff0, 2, 0 * COIN, extraNonce);
-        const std::string s = genesis.GetHash().ToString();
-        // std::cout << "zcoin new hashMerkleRoot hash: " << genesis.hashMerkleRoot.ToString() << std::endl;
+//        const std::string s = genesis.GetHash().ToString();
+//        std::cout << "zcoin new hashMerkleRoot hash: " << genesis.hashMerkleRoot.ToString() << std::endl;
         consensus.hashGenesisBlock = genesis.GetHash();
         assert(consensus.hashGenesisBlock == uint256S("0x4381deb85b1b2c9843c222944b616d997516dcbd6a964e1eaf0def0830695233"));
         assert(genesis.hashMerkleRoot == uint256S("0x365d2aa75d061370c9aefdabac3985716b1e3b4bb7c4af4ed54f25e5aaa42783"));
@@ -408,7 +408,7 @@ public:
         extraNonce[1] = 0x00;
         extraNonce[2] = 0x00;
         extraNonce[3] = 0x00;
-        genesis = CreateGenesisBlock(ZC_GENESIS_BLOCK_TIME, 1, 0x207fffff, 1, 0 * COIN, extraNonce);
+        genesis = CreateGenesisBlock(ZC_GENESIS_BLOCK_TIME, 3, 0x207fffff, 1, 0 * COIN, extraNonce);
         consensus.hashGenesisBlock = genesis.GetHash();
 
         vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.
@@ -429,7 +429,7 @@ public:
         };
         base58Prefixes[PUBKEY_ADDRESS] = std::vector < unsigned char > (1, 65);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector < unsigned char > (1, 178);
-        base58Prefixes[SECRET_KEY] = std::vector < unsigned char > (1, 239);
+        base58Prefixes[SECRET_KEY] = std::vector < unsigned char > (1, 185);
         base58Prefixes[EXT_PUBLIC_KEY] = boost::assign::list_of(0x04)(0x35)(0x87)(0xCF).convert_to_container < std::vector < unsigned char > > ();
         base58Prefixes[EXT_SECRET_KEY] = boost::assign::list_of(0x04)(0x35)(0x83)(0x94).convert_to_container < std::vector < unsigned char > > ();
 
@@ -443,9 +443,12 @@ public:
         nModulusV2StartBlock = 130;
         nModulusV1MempoolStopBlock = 135;
         nModulusV1StopBlock = 140;
-        nMTPSwitchTime = INT_MAX;
+        nMTPSwitchTime = 1;
         nDifficultyAdjustStartBlock = 0;
         nFixedDifficulty = 0;
+
+        if(genesis.IsMTP())
+            genesis.mtpHashData = std::make_shared<CMTPHashData>();
     }
 
     void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout) {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -408,16 +408,8 @@ public:
         extraNonce[1] = 0x00;
         extraNonce[2] = 0x00;
         extraNonce[3] = 0x00;
-        genesis = CreateGenesisBlock(ZC_GENESIS_BLOCK_TIME, 414098458, 0x207fffff, 1, 0 * COIN, extraNonce);
+        genesis = CreateGenesisBlock(ZC_GENESIS_BLOCK_TIME, 1, 0x207fffff, 1, 0 * COIN, extraNonce);
         consensus.hashGenesisBlock = genesis.GetHash();
-        //btzc: update regtest zcoin hashGenesisBlock and hashMerkleRoot
-//        std::cout << "zcoin regtest genesisBlock hash: " << consensus.hashGenesisBlock.ToString() << std::endl;
-//        std::cout << "zcoin regtest hashMerkleRoot hash: " << genesis.hashMerkleRoot.ToString() << std::endl;
-        //btzc: update testnet zcoin hashGenesisBlock and hashMerkleRoot
-        //assert(consensus.hashGenesisBlock ==
-        //       uint256S("0x0080c7bf30bb2579ed9c93213475bf8fafc1f53807da908cde19cf405b9eb55b"));
-        //assert(genesis.hashMerkleRoot ==
-        //       uint256S("0x25b361d60bc7a66b311e72389bf5d9add911c735102bcb6425f63aceeff5b7b8"));
 
         vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.
         vSeeds.clear();      //!< Regtest mode doesn't have any DNS seeds.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -212,6 +212,8 @@ public:
         nModulusV1MempoolStopBlock = ZC_MODULUS_V1_MEMPOOL_STOP_BLOCK;
 	    nModulusV1StopBlock = ZC_MODULUS_V1_STOP_BLOCK;
         nMTPSwitchTime = SWITCH_TO_MTP_BLOCK_HEADER;
+        nDifficultyAdjustStartBlock = 0;
+        nFixedDifficulty = 0;
     }
 };
 
@@ -345,6 +347,8 @@ public:
         nModulusV1MempoolStopBlock = ZC_MODULUS_V1_TESTNET_MEMPOOL_STOP_BLOCK;
 	    nModulusV1StopBlock = ZC_MODULUS_V1_TESTNET_STOP_BLOCK;
         nMTPSwitchTime = 1;
+        nDifficultyAdjustStartBlock = 5000;
+        nFixedDifficulty = 0x2000ffff;
     }
 };
 
@@ -448,6 +452,8 @@ public:
         nModulusV1MempoolStopBlock = 135;
         nModulusV1StopBlock = 140;
         nMTPSwitchTime = INT_MAX;
+        nDifficultyAdjustStartBlock = 0;
+        nFixedDifficulty = 0;
     }
 
     void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout) {

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -93,6 +93,11 @@ public:
 
     /** switch to MTP time */
     uint32_t nMTPSwitchTime;
+
+    /** don't adjust difficulty until some block number */
+    int nDifficultyAdjustStartBlock;
+    /** fixed diffuculty to use before adjustment takes place */
+    int nFixedDifficulty;
 	
 protected:
     CChainParams() {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4171,8 +4171,8 @@ ContextualCheckBlockHeader(const CBlockHeader &block, CValidationState &state, c
     int32_t nVersionMTP = block.mtpHashData ? block.nVersionMTP : 0;
     bool fBlockHasMTP = block.nVersion >= (CBlock::CURRENT_VERSION | (GetZerocoinChainID() * BLOCK_VERSION_CHAIN_START)| nVersionMTP);
 
-    if (block.IsMTP() && !fBlockHasMTP)
-        return state.Invalid(false, REJECT_OBSOLETE, strprintf("bad-version(0x%08x), block.IsMTP(): %d, fBlockHasMTP: %d", block.nVersion, block.IsMTP(), fBlockHasMTP),strprintf("rejected nVersion=0x%08x block", block.nVersion));
+    if (block.IsMTP() != fBlockHasMTP)
+        return state.Invalid(false, REJECT_OBSOLETE, strprintf("bad-version(0x%08x), block.IsMTP(): %d, fBlockHasMTP: %d", block.nVersion, block.IsMTP(), fBlockHasMTP),strprintf("rejected nVersion=0x%08x block; nTime=%d, mtpSwitchTime=%d", block.nVersion, block.nTime, Params().nMTPSwitchTime));
     
 	// Check proof of work
     if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4171,8 +4171,8 @@ ContextualCheckBlockHeader(const CBlockHeader &block, CValidationState &state, c
     int32_t nVersionMTP = block.mtpHashData ? block.nVersionMTP : 0;
     bool fBlockHasMTP = block.nVersion >= (CBlock::CURRENT_VERSION | (GetZerocoinChainID() * BLOCK_VERSION_CHAIN_START)| nVersionMTP);
 
-    if (block.IsMTP() != fBlockHasMTP)
-		return state.Invalid(false, REJECT_OBSOLETE, strprintf("bad-version(0x%08x)", block.nVersion),strprintf("rejected nVersion=0x%08x block", block.nVersion));
+    if (block.IsMTP() && !fBlockHasMTP)
+        return state.Invalid(false, REJECT_OBSOLETE, strprintf("bad-version(0x%08x), block.IsMTP(): %d, fBlockHasMTP: %d", block.nVersion, block.IsMTP(), fBlockHasMTP),strprintf("rejected nVersion=0x%08x block", block.nVersion));
     
 	// Check proof of work
     if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -38,23 +38,12 @@ double GetDifficultyHelper(unsigned int nBits) {
 
 // zcoin GetNextWorkRequired
 unsigned int GetNextWorkRequired(const CBlockIndex *pindexLast, const CBlockHeader *pblock, const Consensus::Params &params) {
-    bool fTestNet = Params().NetworkIDString() == CBaseChainParams::TESTNET;
+    auto chainParams = Params();
+    bool fTestNet = chainParams.NetworkIDString() == CBaseChainParams::TESTNET;
+    bool fMainNet = chainParams.NetworkIDString() == CBaseChainParams::MAIN;
 
-    // Zcoin - MTP
-	//if(!fTestNet && pindexLast->nHeight + 1 >= HF_MTP_HEIGHT){
-    /*if(!fTestNet && pblock->nTime > 1526971395){
-		return 0x2000ffff;
-	}*/
-
-	//if(fTestNet && pindexLast->nHeight + 1 >= HF_MTP_HEIGHT_TESTNET){
-    if(fTestNet && pindexLast->nHeight < 5000){
-			return 0x2000ffff;
-	}
-
-    // allow instamine first x blocks on testnet for distribution testing
-	if(fTestNet && pindexLast->nHeight < 5000){
-		return bnProofOfWorkLimit.GetCompact();
-	}
+    if (pindexLast->nHeight < chainParams.nDifficultyAdjustStartBlock)
+        return chainParams.nFixedDifficulty;
 
 	if (pindexLast == NULL) {
         return bnProofOfWorkLimit.GetCompact();
@@ -77,16 +66,11 @@ unsigned int GetNextWorkRequired(const CBlockIndex *pindexLast, const CBlockHead
 
     // 9/29/2016 - Reset to Lyra2(2,block_height,256) due to ASIC KnC Miner Scrypt
     // 36 block look back, reset to mininmum diff
-    if (!fTestNet && pindexLast->nHeight + 1 >= HF_LYRA2VAR_HEIGHT && pindexLast->nHeight + 1 <= HF_LYRA2VAR_HEIGHT + 36 - 1) {
+    if (fMainNet && pindexLast->nHeight + 1 >= HF_LYRA2VAR_HEIGHT && pindexLast->nHeight + 1 <= HF_LYRA2VAR_HEIGHT + 36 - 1) {
         return bnProofOfWorkLimit.GetCompact();
     }
-    // reset to minimum diff at testnet after scrypt_n, 6 block look back
-    if (fTestNet && pindexLast->nHeight + 1 >= HF_LYRA2VAR_HEIGHT_TESTNET && pindexLast->nHeight + 1 <= HF_LYRA2VAR_HEIGHT_TESTNET + 6 - 1) {
-        return bnProofOfWorkLimit.GetCompact();
-    }
-
     // 02/11/2017 - Increase diff to match with new hashrates of Lyra2Z algo
-    if ((!fTestNet && pindexLast->nHeight + 1 == HF_LYRA2Z_HEIGHT) || (fTestNet && pindexLast->nHeight + 1 == HF_LYRA2Z_HEIGHT_TESTNET)) {
+    if (fMainNet && pindexLast->nHeight + 1 == HF_LYRA2Z_HEIGHT) {
         CBigNum bnNew;
         bnNew.SetCompact(pindexLast->nBits);
         bnNew /= 20000; // increase the diff by 20000x since the new hashrate is approx. 20000 times higher

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -31,6 +31,7 @@
 #include <boost/shared_ptr.hpp>
 
 #include <univalue.h>
+#include "crypto/MerkleTreeProof/mtp.h"
 
 using namespace std;
 
@@ -123,10 +124,16 @@ UniValue generateBlocks(boost::shared_ptr<CReserveScript> coinbaseScript, int nG
             LOCK(cs_main);
             IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce);
         }
-        while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus())) {
-            ++pblock->nNonce;
-            --nMaxTries;
+
+        if(pblock->IsMTP()){
+            pblock->mtpHashValue = mtp::hash(*pblock, Params().GetConsensus().powLimit);
+        } else {
+            while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus())) {
+                ++pblock->nNonce;
+                --nMaxTries;
+            }
         }
+
         if (nMaxTries == 0) {
             break;
         }

--- a/src/test/chainparams_tests.cpp
+++ b/src/test/chainparams_tests.cpp
@@ -1,0 +1,30 @@
+#include <test/test_bitcoin.h>
+#include <chainparams.h>
+#include <boost/test/unit_test.hpp>
+
+struct ChainParamsTestingSetup : public TestingSetup
+{
+    ChainParamsTestingSetup() : TestingSetup(CBaseChainParams::REGTEST, "1")
+    {
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(Regtest, ChainParamsTestingSetup)
+
+BOOST_AUTO_TEST_CASE(regtest_chainparams_verification)
+{
+    CBlock genesis = Params(CBaseChainParams::REGTEST).GenesisBlock();
+    auto const & consensus = Params(CBaseChainParams::REGTEST).GetConsensus();
+
+//        std::cout << "zcoin regtest genesisBlock hash: " << consensus.hashGenesisBlock.ToString() << std::endl;
+//        std::cout << "zcoin regtest hashMerkleRoot hash: " << genesis.hashMerkleRoot.ToString() << std::endl;
+
+    BOOST_CHECK(consensus.hashGenesisBlock == uint256S("0xee98d9dc0da1f3378edeeed1edcaf7d657952257d4700d594eb7c08ac1d6fa9a"));
+    BOOST_CHECK(genesis.hashMerkleRoot == uint256S("0x25b361d60bc7a66b311e72389bf5d9add911c735102bcb6425f63aceeff5b7b8"));
+
+    BOOST_CHECK(genesis.nNonce == 3);
+
+    BOOST_CHECK(CheckProofOfWork(genesis.GetHash(), genesis.nBits, consensus));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/mtp_tests.cpp
+++ b/src/test/mtp_tests.cpp
@@ -4,6 +4,13 @@
 #include <iostream>
 #include <boost/test/unit_test.hpp>
 
+//#include <univalue.h>
+//#include "wallet/wallet.h"
+//
+//extern UniValue generate(const UniValue& params, bool fHelp);
+//extern UniValue keypoolrefill(const UniValue& params, bool fHelp);
+//extern CRPCTable tableRPC;
+
 using namespace std;
 
 struct MtpTestingSetup : public TestingSetup
@@ -12,6 +19,8 @@ struct MtpTestingSetup : public TestingSetup
     {
     }
 };
+
+
 
 BOOST_FIXTURE_TEST_SUITE(mtp_tests, MtpTestingSetup)
 
@@ -94,23 +103,36 @@ BOOST_AUTO_TEST_CASE(mtp_block_integrity_test)
     BOOST_CHECK(false == mtp::verify(block3.nNonce+1, block3, pow_limit));
 }
 
-#include "chainparams.h"
+//std::ostream & print_what_should(std::ostream &  ostr,  std::string const & addr)
+//{
+//    ostr << "sed -ri 's/" << addr << "/" << bitcoin_address_to_zcoin(addr) << "/g'" << std::endl;
+//    return ostr;
+//}
+//
+//BOOST_AUTO_TEST_CASE(mtp_printer)
+//{
+//    print_what_should(std::cout, "cSFpb16iAbS9KP63UnHv6XjPxWBqmAgTa4U3SeAxyHRvsLimyfNk") << std::endl;
+//}
+//
+//BOOST_AUTO_TEST_CASE(mtp_temp)
+//{
+//    CWallet * pwalletMain = new CWallet("wallet_test.dat");
+//    bool fFirstRun = true;
+//    pwalletMain->LoadWallet(fFirstRun);
+//    RegisterValidationInterface(pwalletMain);
+//
+//    RegisterWalletRPCCommands(tableRPC);
+//
+//
+//    UniValue v(UniValue::VARR), v1;
+//    v1.setInt(1);
+//    v.push_back(v1);
+//
+//    keypoolrefill(v, false);
+//
+//    generate(v, false);
+//
+//}
 
-BOOST_AUTO_TEST_CASE(mtp_regtest_genesis_block_test)
-{
-    CBlock genesis = Params(CBaseChainParams::REGTEST).GenesisBlock();
-    auto const & consensus = Params(CBaseChainParams::REGTEST).GetConsensus();
-
-//        std::cout << "zcoin regtest genesisBlock hash: " << consensus.hashGenesisBlock.ToString() << std::endl;
-//        std::cout << "zcoin regtest hashMerkleRoot hash: " << genesis.hashMerkleRoot.ToString() << std::endl;
-
-    BOOST_CHECK(consensus.hashGenesisBlock == uint256S("0xee98d9dc0da1f3378edeeed1edcaf7d657952257d4700d594eb7c08ac1d6fa9a"));
-    BOOST_CHECK(genesis.hashMerkleRoot == uint256S("0x25b361d60bc7a66b311e72389bf5d9add911c735102bcb6425f63aceeff5b7b8"));
-
-    auto hash = mtp::hash(genesis, Params(CBaseChainParams::REGTEST).GetConsensus().powLimit);
-
-    BOOST_CHECK(genesis.nNonce == 1);
-    BOOST_CHECK(hash == genesis.GetHash());
-}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/mtp_tests.cpp
+++ b/src/test/mtp_tests.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(mtp_block_integrity_test)
     RandAddSeed();
 
     CBlock block1;
-    
+
     block1.nVersion = CBlock::CURRENT_VERSION;
     block1.hashPrevBlock = GetRandHash();
     block1.hashMerkleRoot = GetRandHash();
@@ -69,8 +69,8 @@ BOOST_AUTO_TEST_CASE(mtp_block_integrity_test)
 
     CBlock block2(block1); block2.mtpHashData = std::shared_ptr<CMTPHashData>(new CMTPHashData); block2.nVersionMTP = 1;
     CBlock block3(block1); block3.mtpHashData = std::shared_ptr<CMTPHashData>(new CMTPHashData); block3. nVersionMTP = 1;
-    
-    uint256 pow_limit = uint256S("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+
+    uint256 const pow_limit = Params(CBaseChainParams::REGTEST).GetConsensus().powLimit ;
 
     auto hash1 = mtp::hash(block1, pow_limit);
 
@@ -94,5 +94,23 @@ BOOST_AUTO_TEST_CASE(mtp_block_integrity_test)
     BOOST_CHECK(false == mtp::verify(block3.nNonce+1, block3, pow_limit));
 }
 
+#include "chainparams.h"
+
+BOOST_AUTO_TEST_CASE(mtp_regtest_genesis_block_test)
+{
+    CBlock genesis = Params(CBaseChainParams::REGTEST).GenesisBlock();
+    auto const & consensus = Params(CBaseChainParams::REGTEST).GetConsensus();
+
+//        std::cout << "zcoin regtest genesisBlock hash: " << consensus.hashGenesisBlock.ToString() << std::endl;
+//        std::cout << "zcoin regtest hashMerkleRoot hash: " << genesis.hashMerkleRoot.ToString() << std::endl;
+
+    BOOST_CHECK(consensus.hashGenesisBlock == uint256S("0xee98d9dc0da1f3378edeeed1edcaf7d657952257d4700d594eb7c08ac1d6fa9a"));
+    BOOST_CHECK(genesis.hashMerkleRoot == uint256S("0x25b361d60bc7a66b311e72389bf5d9add911c735102bcb6425f63aceeff5b7b8"));
+
+    auto hash = mtp::hash(genesis, Params(CBaseChainParams::REGTEST).GetConsensus().powLimit);
+
+    BOOST_CHECK(genesis.nNonce == 1);
+    BOOST_CHECK(hash == genesis.GetHash());
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tor/src/test/test_crypto_slow.c
+++ b/src/tor/src/test/test_crypto_slow.c
@@ -601,14 +601,10 @@ struct testcase_t slow_crypto_tests[] = {
   { "libscrypt_eq_openssl", test_libscrypt_eq_openssl, 0, NULL, NULL },
 #endif
 #endif /* defined(HAVE_LIBSCRYPT) */
-  { "s2k_pbkdf2", test_crypto_s2k_general, 0, &passthrough_setup,
-    (void*)"pbkdf2" },
-  { "s2k_rfc2440_general", test_crypto_s2k_general, 0, &passthrough_setup,
-    (void*)"rfc2440" },
-  { "s2k_rfc2440_legacy", test_crypto_s2k_general, 0, &passthrough_setup,
-    (void*)"rfc2440-legacy" },
-  { "s2k_errors", test_crypto_s2k_errors, 0, NULL, NULL },
-  { "scrypt_vectors", test_crypto_scrypt_vectors, 0, NULL, NULL },
+  { "s2k_pbkdf2", test_crypto_s2k_general, 0, &passthrough_setup, (void*)"pbkdf2" },
+  { "s2k_rfc2440_general", test_crypto_s2k_general, 0, &passthrough_setup, (void*)"rfc2440" },
+  { "s2k_rfc2440_legacy", test_crypto_s2k_general, 0, &passthrough_setup,  (void*)"rfc2440-legacy" },
+  { "s2k_errors", test_crypto_s2k_errors, 0, NULL, NULL },  { "scrypt_vectors", test_crypto_scrypt_vectors, 0, NULL, NULL },
   { "pbkdf2_vectors", test_crypto_pbkdf2_vectors, 0, NULL, NULL },
   { "pwbox", test_crypto_pwbox, 0, NULL, NULL },
   ED25519_TEST(fuzz_donna, TT_FORK),

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3701,7 +3701,7 @@ bool CWallet::CreateZerocoinSpendTransaction(std::string &thirdPartyaddress, int
             uint256 accumulatorBlockHash;      // to be used in zerocoin spend v2
 
             int coinId = INT_MAX;
-            int coinHeight;
+            int coinHeight = 0;
 
             BOOST_FOREACH(const CZerocoinEntry &minIdPubcoin, listPubCoin) {
                 if (minIdPubcoin.denomination == denomination


### PR DESCRIPTION
These changes allow for bitcore-node-zcoin tests to run zcoind in the regtest mode.
For regtest chain params I mined the genesis block and it returned the nonce 1.