### PR TITLE
Enable parallelization when execute make in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl -L http://download.oracle.com/berkeley-db/db-4.8.30.tar.gz | tar -xz -C /tmp && \
     cd /tmp/db-4.8.30/build_unix && \
     ../dist/configure --enable-cxx --includedir=/usr/include/bdb4.8 --libdir=/usr/lib && \
-    make && make install && \
+    make -j$(nproc) && make install && \
     cd / && rm -rf /tmp/db-4.8.30
 
 # Create user to run daemon
@@ -33,7 +33,7 @@ COPY . /tmp/zcoin/
 RUN cd /tmp/zcoin && \
     ./autogen.sh && \
     ./configure --without-gui --prefix=/usr && \
-    make && \
+    make -j$(nproc) && \
     make check && \
     make install && \
     cd / && rm -rf /tmp/zcoin


### PR DESCRIPTION
With information gotten from https://github.com/soerenmartius in #251, we can increase the maximum number of job when execute `make` to the number of available CPUs to make it faster. It can prevent starving host's resource by limit amount of CPU shares when execute `docker build`.