### PR TITLE
Fix switch-case fallthrough warning on GCC 7

### DIFF
--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -783,23 +783,27 @@ inline const char* FormatIterator::streamStateFromFormat(std::ostream& out,
             break;
         case 'X':
             out.setf(std::ios::uppercase);
+            // fall-thru
         case 'x': case 'p':
             out.setf(std::ios::hex, std::ios::basefield);
             intConversion = true;
             break;
         case 'E':
             out.setf(std::ios::uppercase);
+            // fall-thru
         case 'e':
             out.setf(std::ios::scientific, std::ios::floatfield);
             out.setf(std::ios::dec, std::ios::basefield);
             break;
         case 'F':
             out.setf(std::ios::uppercase);
+            // fall-thru
         case 'f':
             out.setf(std::ios::fixed, std::ios::floatfield);
             break;
         case 'G':
             out.setf(std::ios::uppercase);
+            // fall-thru
         case 'g':
             out.setf(std::ios::dec, std::ios::basefield);
             // As in boost::format, let stream decide float format.


### PR DESCRIPTION
This warning raised when building with GCC 7 or above:

```
tinyformat.h: In static member function ‘static const char* tinyformat::detail::FormatIterator::streamStateFromFormat(std::ostream&, unsigned int&, const char*, int, int)’:
tinyformat.h:785:21: warning: this statement may fall through [-Wimplicit-fallthrough=]
             out.setf(std::ios::uppercase);
             ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
tinyformat.h:786:9: note: here
         case 'x': case 'p':
         ^~~~
tinyformat.h:791:21: warning: this statement may fall through [-Wimplicit-fallthrough=]
             out.setf(std::ios::uppercase);
             ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
tinyformat.h:792:9: note: here
         case 'e':
         ^~~~
tinyformat.h:797:21: warning: this statement may fall through [-Wimplicit-fallthrough=]
             out.setf(std::ios::uppercase);
             ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
tinyformat.h:798:9: note: here
         case 'f':
         ^~~~
tinyformat.h:802:21: warning: this statement may fall through [-Wimplicit-fallthrough=]
             out.setf(std::ios::uppercase);
             ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
tinyformat.h:803:9: note: here
         case 'g':
         ^~~~
```

More information can be see here: https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/