### PR TITLE
Correct Spelling of Tor

### DIFF
--- a/src/qt/forms/overviewpage.h
+++ b/src/qt/forms/overviewpage.h
@@ -389,7 +389,7 @@ public:
 #endif // QT_NO_TOOLTIP
         labelPendingText->setText(QApplication::translate("OverviewPage", "Pending:", 0, QApplication::UnicodeUTF8));
         labelSpendable->setText(QApplication::translate("OverviewPage", "Spendable:", 0, QApplication::UnicodeUTF8));
-        checkboxEnabledTor->setText(QApplication::translate("OverviewPage", "Anonymous communication with TOR", 0, QApplication::UnicodeUTF8));
+        checkboxEnabledTor->setText(QApplication::translate("OverviewPage", "Anonymous communication with Tor", 0, QApplication::UnicodeUTF8));
         label_4->setText(QApplication::translate("OverviewPage", "Recent transactions", 0, QApplication::UnicodeUTF8));
 #ifndef QT_NO_TOOLTIP
         labelTransactionsStatus->setToolTip(QApplication::translate("OverviewPage", "The displayed information may be out of date. Your wallet automatically synchronizes with the Zcoin network after a connection is established, but this process has not completed yet.", 0, QApplication::UnicodeUTF8));

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -425,7 +425,7 @@
           <bool>true</bool>
          </property>
          <property name="text">
-          <string>Anonymous communication with TOR</string>
+          <string>Anonymous communication with Tor</string>
          </property>
          <property name="checked">
           <bool>false</bool>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -173,15 +173,15 @@ void OverviewPage::handleEnabledTorChanged(){
 
 	if(ui->checkboxEnabledTor->isChecked()){
 		if (WriteBinaryFileTor(pathTorSetting.string().c_str(), "1")) {
-			msgBox.setText("Please restart the Zcoin wallet to route your connection to TOR to protect your IP address. \nSyncing your wallet might be slower with TOR.");
+			msgBox.setText("Please restart the Zcoin wallet to route your connection through Tor to protect your IP address. \nSyncing your wallet might be slower with TOR.");
 		} else {
-			msgBox.setText("Anonymous communication cannot enable");
+			msgBox.setText("Anonymous communication cannot be enabled");
 		}
 	}else{
 		if (WriteBinaryFileTor(pathTorSetting.string().c_str(), "0")) {
-			msgBox.setText("Please restart the Zcoin wallet to disable route your connection to TOR to protect your IP address.");
+			msgBox.setText("Please restart the Zcoin wallet to disable routing of your connection through Tor to protect your IP address.");
 		} else {
-			msgBox.setText("Anonymous communication cannot disable");
+			msgBox.setText("Anonymous communication cannot be disabled");
 		}
 	}
 	msgBox.exec();


### PR DESCRIPTION
From the [Tor FAQ](https://www.torproject.org/docs/faq.html.en):
>Note: even though it originally came from an acronym, Tor is not spelled "TOR". Only the first letter is capitalized. In fact, we can usually spot people who haven't read any of our website (and have instead learned everything they know about Tor from news articles) by the fact that they spell it wrong.

That's not us, right? :wink: