### PR TITLE
Fix for the unit tests -- rejected

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Zcoin v0.13.6.9
+Zcoin v0.13.7.1
 =============
 
 [![Build Status](https://travis-ci.com/zcoinofficial/zcoin.svg?branch=CI)](https://travis-ci.com/zcoinofficial/zcoin)

--- a/src/amount.h
+++ b/src/amount.h
@@ -28,7 +28,7 @@ extern const std::string CURRENCY_UNIT;
  * critical; in unusual circumstances like a(nother) overflow bug that allowed
  * for the creation of coins out of thin air modification could lead to a fork.
  * */
-static const CAmount MAX_MONEY = 21000000 * COIN;
+static const CAmount MAX_MONEY = 30500000 * COIN;
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
 /**

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -57,8 +57,7 @@ BOOST_AUTO_TEST_CASE(subsidy_limit_test)
         nSum += nSubsidy * 1000;
         BOOST_CHECK(MoneyRange(nSum));
     }
-    //TODO: re-calculate correct sum here (halving block has changed from 210000 to 305000)
-    //BOOST_CHECK_EQUAL(nSum, 2099999997690000ULL);
+    BOOST_CHECK_EQUAL(nSum, 3049999996645000ULL);
 }
 
 bool ReturnFalse() { return false; }


### PR DESCRIPTION
The switch to MTP will halve rewards per block because the distance between blocks will reduce to 5 minutes. We change bitcoin's subsidy halving block number (originally 210000) to keep total reward amount over given period of time exactly the same. This is a fix for bitcoin test, nothing more.