### PR TITLE
Fix rounduint64() for Windows

### DIFF
--- a/src/exodus/convert.cpp
+++ b/src/exodus/convert.cpp
@@ -18,9 +18,9 @@ static bool isBigEndian()
   return 1 == bint.c[0];
 }
 
-uint64_t rounduint64(long double ld)
+uint64_t rounduint64(double ld)
 {
-    return static_cast<uint64_t>(roundl(fabsl(ld)));
+    return static_cast<uint64_t>(round(fabs(ld)));
 }
 
 void swapByteOrder16(uint16_t& us)

--- a/src/exodus/convert.h
+++ b/src/exodus/convert.h
@@ -12,10 +12,10 @@ namespace exodus
  * is greater or equal than .5, then the result is rounded
  * up and down otherwise.
  */
-uint64_t rounduint64(long double);
+uint64_t rounduint64(double);
 
 /**
- * Swaps byte order on little-endian systems and does nothing 
+ * Swaps byte order on little-endian systems and does nothing
  * otherwise. swapByteOrder cycles on LE systems.
  */
 void swapByteOrder16(uint16_t&);

--- a/src/exodus/test/rounduint64_tests.cpp
+++ b/src/exodus/test/rounduint64_tests.cpp
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(rounduint64_whole_units)
 }
 
 BOOST_AUTO_TEST_CASE(rounduint64_round_below_point_5)
-{    
+{
     BOOST_CHECK_EQUAL(0U, rounduint64(0.49999999));
     BOOST_CHECK_EQUAL(1U, rounduint64(1.49999999));
     BOOST_CHECK_EQUAL(2U, rounduint64(2.49999999));
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(rounduint64_round_below_point_5)
 }
 
 BOOST_AUTO_TEST_CASE(rounduint64_round_point_5)
-{    
+{
     BOOST_CHECK_EQUAL(1U, rounduint64(0.5));
     BOOST_CHECK_EQUAL(2U, rounduint64(1.5));
     BOOST_CHECK_EQUAL(3U, rounduint64(2.5));
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(rounduint64_round_point_5)
 }
 
 BOOST_AUTO_TEST_CASE(rounduint64_round_over_point_5)
-{    
+{
     BOOST_CHECK_EQUAL(1U, rounduint64(0.50000001));
     BOOST_CHECK_EQUAL(2U, rounduint64(1.50000001));
     BOOST_CHECK_EQUAL(3U, rounduint64(2.50000001));
@@ -50,31 +50,31 @@ BOOST_AUTO_TEST_CASE(rounduint64_round_over_point_5)
 }
 
 BOOST_AUTO_TEST_CASE(rounduint64_limits)
-{    
-    BOOST_CHECK_EQUAL( // 1 byte signed
+{
+    BOOST_CHECK_EQUAL( // 8 bits signed
             127U,
             rounduint64(127.0));
-    BOOST_CHECK_EQUAL( // 1 byte unsigned
+    BOOST_CHECK_EQUAL( // 8 bits unsigned
             255U,
             rounduint64(255.0));
-    BOOST_CHECK_EQUAL( // 2 byte signed
+    BOOST_CHECK_EQUAL( // 16 bits signed
             32767U,
             rounduint64(32767.0));
-    BOOST_CHECK_EQUAL( // 2 byte unsigned
+    BOOST_CHECK_EQUAL( // 16 bits unsigned
             65535U,
             rounduint64(65535.0));
-    BOOST_CHECK_EQUAL( // 4 byte signed
+    BOOST_CHECK_EQUAL( // 32 bits signed
             2147483647U,
             rounduint64(2147483647.0));
-    BOOST_CHECK_EQUAL( // 4 byte unsigned
+    BOOST_CHECK_EQUAL( // 32 bits unsigned
             4294967295U,
-            rounduint64(4294967295.0L));
-    BOOST_CHECK_EQUAL( // 8 byte signed
-            9223372036854775807U,
-            rounduint64(9223372036854775807.0L));
-    BOOST_CHECK_EQUAL( // 8 byte unsigned
-            18446744073709551615U,
-            rounduint64(18446744073709551615.0L));
+            rounduint64(4294967295.0));
+    BOOST_CHECK_EQUAL( // 52 bits signed
+            4503599627370496U,
+            rounduint64(4503599627370496.0));
+    BOOST_CHECK_EQUAL( // 52 bits unsigned
+            9007199254740992U,
+            rounduint64(9007199254740992.0));
 }
 
 BOOST_AUTO_TEST_CASE(rounduint64_types)
@@ -103,11 +103,11 @@ BOOST_AUTO_TEST_CASE(rounduint64_promotion)
 {
     BOOST_CHECK_EQUAL(42U, rounduint64(static_cast<int8_t>(42)));
     BOOST_CHECK_EQUAL(42U, rounduint64(static_cast<uint8_t>(42)));
-    BOOST_CHECK_EQUAL(42U, rounduint64(static_cast<int16_t>(42)));    
+    BOOST_CHECK_EQUAL(42U, rounduint64(static_cast<int16_t>(42)));
     BOOST_CHECK_EQUAL(42U, rounduint64(static_cast<uint16_t>(42)));
     BOOST_CHECK_EQUAL(42U, rounduint64(static_cast<int32_t>(42)));
     BOOST_CHECK_EQUAL(42U, rounduint64(static_cast<uint32_t>(42)));
-    BOOST_CHECK_EQUAL(42U, rounduint64(static_cast<int64_t>(42)));    
+    BOOST_CHECK_EQUAL(42U, rounduint64(static_cast<int64_t>(42)));
     BOOST_CHECK_EQUAL(42U, rounduint64(static_cast<uint64_t>(42)));
     BOOST_CHECK_EQUAL(42U, rounduint64(static_cast<float>(42)));
     BOOST_CHECK_EQUAL(42U, rounduint64(static_cast<double>(42)));
@@ -126,21 +126,20 @@ BOOST_AUTO_TEST_CASE(rounduint64_absolute)
             rounduint64(-65536.0),
             rounduint64(65536.0));
     BOOST_CHECK_EQUAL(
-            rounduint64(-2147483648.0L),
-            rounduint64(2147483648.0L));
-    BOOST_CHECK_EQUAL(            
-            rounduint64(-4294967296.0L),
-            rounduint64(4294967296.0L));
+            rounduint64(-2147483648.0),
+            rounduint64(2147483648.0));
     BOOST_CHECK_EQUAL(
-            rounduint64(-9223372036854775807.0L),
-            rounduint64(9223372036854775807.0L));
+            rounduint64(-4294967296.0),
+            rounduint64(4294967296.0));
+    BOOST_CHECK_EQUAL(
+            rounduint64(-9223372036854775807.0),
+            rounduint64(9223372036854775807.0));
 }
 
 BOOST_AUTO_TEST_CASE(rounduint64_special_cases)
-{    
+{
     BOOST_CHECK_EQUAL(0U, rounduint64(static_cast<double>(0.49999999999999994)));
     BOOST_CHECK_EQUAL(2147483648U, rounduint64(static_cast<int32_t>(-2147483647-1)));
 }
-
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This fix the following issue when running on Windows:

```
exodus/test/rounduint64_tests.cpp(77): error: in "exodus_rounduint64_tests/rounduint64_limits": check 18446744073709551615U == rounduint64(18446744073709551615.0L) has failed [18446744073709551615 != 0]
```

This caused by Windows does not support 80-bit extended precision floating point via `long double` (it just an alias to `double` ([source](https://msdn.microsoft.com/en-us/library/9cx8xs15.aspx)).