### PR TITLE
Changes to mintmanyzerocoin 

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -115,7 +115,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
         //[zcoin]
     { "setmininput", 0 },
     { "mintzerocoin", 0 },
-    { "mintmanyzerocoin", 0 },
     { "spendzerocoin", 0 },
     { "spendmanyzerocoin", 0 },
     { "setgenerate", 0 },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2827,7 +2827,7 @@ UniValue mintmanyzerocoin(const UniValue& params, bool fHelp)
                 break;
             default:
                 throw runtime_error(
-                    "mintmanyzerocoin <amount>(1,10,25,50,100) (\"zcoinaddress\")\n");
+                    "denomination must be one of (1,10,25,50,100)\n");
         }
 
 
@@ -2838,7 +2838,7 @@ UniValue mintmanyzerocoin(const UniValue& params, bool fHelp)
         
         if(amount < 0){
                 throw runtime_error(
-                    "mintmanyzerocoin {<denomination>(1,10,25,50,100):\"amount\"...}\n");
+                    "amounts must be greater than 0.\n");
         }
 
         for(int64_t i=0; i<amount; i++){

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2757,6 +2757,7 @@ UniValue mintzerocoin(const UniValue& params, bool fHelp)
         zerocoinTx.serialNumber = newCoin.getSerialNumber();
         const unsigned char *ecdsaSecretKey = newCoin.getEcdsaSeckey();
         zerocoinTx.ecdsaSecretKey = std::vector<unsigned char>(ecdsaSecretKey, ecdsaSecretKey+32);
+        pwalletMain->NotifyZerocoinChanged(pwalletMain, zerocoinTx.value.GetHex(), "New (" + std::to_string(zerocoinTx.denomination) + " mint)", CT_NEW);
         walletdb.WriteZerocoinEntry(zerocoinTx);
 
         return wtx.GetHash().GetHex();
@@ -2770,17 +2771,17 @@ UniValue mintmanyzerocoin(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() == 0 || params.size() % 2 != 0 || params.size() > 10)
         throw runtime_error(
-                "mintmanyzerocoin <denomination>(1,10,25,50,100), amount, ... }\n"
+                "mintmanyzerocoin <denomination>(1,10,25,50,100), numberOfMints, <denomination>(1,10,25,50,100), numberOfMints, ... }\n"
                 + HelpRequiringPassphrase()
                 + "\nMint 1 or more zerocoins in a single transaction. Amounts must be of denominations specified.\n"
-                + "Specify each denomination followed by it's amount, for all denominations desired.\n"
+                + "Specify each denomination followed by the number of them to mint, for all denominations desired.\n"
                 + "Total amount for all must be less than " + to_string(ZC_MINT_LIMIT) + ".  \n"
                 "\nArguments:\n"
                 "1. \"denomination\"             (integer, required) zerocoin denomination\n"
-                "2. \"amount\"                   (integer, required) amount of mints for chosen denomination\n"
-                "\nExamples:\n"
+                "2. \"numberOfMints\"            (integer, required) amount of mints for chosen denomination\n"
+                "\nExamples:\nThe first example mints denomination 1, one time, for a total XZC valuation of 1.\nThe next example mints denomination 25, ten times, and denomination 50, five times, for a total XZC valuation of 500.\n"
                     + HelpExampleCli("mintmanyzerocoin", "1 1")
-                    + HelpExampleCli("mintmanyzerocoin", "25 10 10 5")
+                    + HelpExampleCli("mintmanyzerocoin", "25 10 50 5")
         );
 
     UniValue sendTo(UniValue::VOBJ);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4463,6 +4463,7 @@ string CWallet::MintAndStoreZerocoin(vector<CRecipient> vecSend,
         zerocoinTx.serialNumber = privCoin.getSerialNumber();
         const unsigned char *ecdsaSecretKey = privCoin.getEcdsaSeckey();
         zerocoinTx.ecdsaSecretKey = std::vector<unsigned char>(ecdsaSecretKey, ecdsaSecretKey+32);
+        NotifyZerocoinChanged(this, zerocoinTx.value.GetHex(), "New (" + std::to_string(zerocoinTx.denomination) + " mint)", CT_NEW);
         walletdb.WriteZerocoinEntry(zerocoinTx);
     }
 
@@ -4650,6 +4651,7 @@ string CWallet::SpendMultipleZerocoin(std::string &thirdPartyaddress, const std:
                     pubCoinTx.serialNumber = pubCoinItem.serialNumber;
                     pubCoinTx.denomination = pubCoinItem.denomination;
                     pubCoinTx.ecdsaSecretKey = pubCoinItem.ecdsaSecretKey;
+                    NotifyZerocoinChanged(this, pubCoinTx.value.GetHex(), "New", CT_UPDATED);
                     CWalletDB(strWalletFile).WriteZerocoinEntry(pubCoinTx);
                     LogPrintf("SpendZerocoin failed, re-updated status -> NotifyZerocoinChanged\n");
                     LogPrintf("pubcoin=%s, isUsed=New\n", pubCoinItem.value.GetHex());

--- a/src/zerocoin_params.h
+++ b/src/zerocoin_params.h
@@ -72,4 +72,6 @@ static const int64_t DUST_HARD_LIMIT = 1000;   // 0.00001 XZC mininput
 // Number of zerocoin spends allowed per block and per transaction
 #define ZC_SPEND_LIMIT         5
 
+// Number of zerocoin mints allowed per transaction
+#define ZC_MINT_LIMIT         100
 #endif


### PR DESCRIPTION
- Change arguments
    To make it easier for the user, Instead of JSON input, inputs are expected in the following format:
    `mintmanyzerocoin <denomination> <amount> <denomination> <amount> ...`
    for all denominations necessary.
- update help message
- display help message on entering command
- fail should available balance be less than mint amount requested
- fail should mint inputs be greater than ZC_MINT_LIMIT (currently 100)
- Update error msgs

- update the `mintzerocoin` RPC function to return the help message should no arguments be entered, as is the standard with other RPC functions

- Correctly signal the GUI on mint status changes.