### PR TITLE
Fix Tor issue when cross compile for Linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1159,7 +1159,7 @@ if test x$need_bundled_univalue = xyes; then
 fi
 
 AX_SUBDIRS_CONFIGURE([src/secp256k1], [[--disable-shared], [--with-pic], [--with-bignum=no], [--enable-module-recovery], [--enable-experimental], [--enable-module-ecdh]])
-AX_SUBDIRS_CONFIGURE([src/tor], [[--disable-unittests], [--disable-system-torrc], [--disable-systemd], [--disable-lzma], [--disable-zstd], [--disable-asciidoc], [--with-openssl-dir=$($PKG_CONFIG --variable=libdir openssl)], [CFLAGS=$($PKG_CONFIG --cflags openssl) -O2]])
+AX_SUBDIRS_CONFIGURE([src/tor], [[--disable-unittests], [--disable-system-torrc], [--disable-systemd], [--disable-lzma], [--disable-zstd], [--disable-asciidoc]])
 
 
 AC_OUTPUT


### PR DESCRIPTION
The reason it fail is because `$PKG_CONFIG --variable=libdir openssl` will try to grab system library instead of library in `depends` directory. I don't know why it also fixed undefined references to `evutil_secure_rng_set_urandom_device_file` too. Maybe the above `pkg-config` mess with configure prefix somehow.

Fixes #188