### PR TITLE
Re-org of TOR Qt checkbox as conf setting

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -478,6 +478,9 @@ std::string HelpMessage(HelpMessageMode mode) {
     strUsage += HelpMessageOpt("-timeout=<n>",
                                strprintf(_("Specify connection timeout in milliseconds (minimum: 1, default: %d)"),
                                          DEFAULT_CONNECT_TIMEOUT));
+    strUsage += HelpMessageOpt("-torsetup",
+                               strprintf(_("Anonymous communication with TOR - Quickstart (default: %d)"),
+                                         DEFAULT_TOR_SETUP));
     strUsage += HelpMessageOpt("-torcontrol=<ip>:<port>",
                                strprintf(_("Tor control port to use if onion listening enabled (default: %s)"),
                                          DEFAULT_TOR_CONTROL));
@@ -1455,9 +1458,8 @@ bool AppInit2(boost::thread_group &threadGroup, CScheduler &scheduler) {
     }
 
     // start tor
-    boost::filesystem::path pathTorSetting = GetDataDir()/"torsetting.dat";
-    std::pair<bool,std::string> torEnabledArg = ReadBinaryFileTor(pathTorSetting.string().c_str());
-    if(torEnabledArg.second != "" && torEnabledArg.second != "0"){
+    bool torEnabled = GetBoolArg("-torsetup", DEFAULT_TOR_SETUP);
+    if(torEnabled){
     	StartTorEnabled(threadGroup, scheduler);
         SetLimited(NET_TOR);
         SetLimited(NET_IPV4);

--- a/src/main.h
+++ b/src/main.h
@@ -146,6 +146,7 @@ static const bool DEFAULT_TXINDEX = true;
 static const bool DEFAULT_TIMESTAMPINDEX = false;
 static const bool DEFAULT_ADDRESSINDEX = false;
 static const bool DEFAULT_SPENTINDEX = false;
+static const bool DEFAULT_TOR_SETUP = false;
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 
 static const bool DEFAULT_TESTSAFEMODE = false;

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -13,7 +13,7 @@
 
 #include "amount.h"
 #include "init.h"
-#include "main.h" // For DEFAULT_SCRIPTCHECK_THREADS
+#include "main.h" // For DEFAULT_SCRIPTCHECK_THREADS && DEFAULT_TOR_SETUP
 #include "net.h"
 #include "txdb.h" // for -dbcache defaults
 #include "intro.h" 
@@ -111,6 +111,11 @@ void OptionsModel::Init(bool resetSettings)
 #endif
 
     // Network
+    if (!settings.contains("fTorSetup"))
+        settings.setValue("fTorSetup", DEFAULT_TOR_SETUP);
+    if (!SoftSetBoolArg("-torsetup", settings.value("fTorSetup").toBool()))
+        addOverriddenOption("-torsetup");
+
     if (!settings.contains("fUseUPnP"))
         settings.setValue("fUseUPnP", DEFAULT_UPNP);
     if (!SoftSetBoolArg("-upnp", settings.value("fUseUPnP").toBool()))
@@ -213,6 +218,9 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
             QStringList strlIpPort = settings.value("addrProxy").toString().split(":", QString::SkipEmptyParts);
             return strlIpPort.at(1);
         }
+
+        case TorSetup:
+            return settings.value("fTorSetup", false);
 
         // separate Tor proxy
         case ProxyUseTor:

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -46,6 +46,7 @@ public:
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
         Listen,                 // bool
+        TorSetup,               // bool
         OptionIDRowCount,
     };
 

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -11,6 +11,8 @@
 #include <QWidget>
 #include <memory>
 
+#include <QSettings>
+
 class ClientModel;
 class TransactionFilterProxy;
 class TxViewDelegate;
@@ -60,6 +62,8 @@ private:
     CAmount currentWatchOnlyBalance;
     CAmount currentWatchUnconfBalance;
     CAmount currentWatchImmatureBalance;
+
+    QSettings settings;
 
     TxViewDelegate *txdelegate;
     std::unique_ptr<TransactionFilterProxy> filter;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -879,36 +879,3 @@ std::string CopyrightHolders(const std::string& strPrefix)
     }
     return strCopyrightHolders;
 }
-
-std::pair<bool,std::string> ReadBinaryFileTor(const std::string &filename, size_t maxsize)
-{
-    FILE *f = fopen(filename.c_str(), "rb");
-    if (f == NULL)
-        return std::make_pair(false,"");
-    std::string retval;
-    char buffer[128];
-    size_t n;
-    while ((n=fread(buffer, 1, sizeof(buffer), f)) > 0) {
-        retval.append(buffer, buffer+n);
-        if (retval.size() > maxsize)
-            break;
-    }
-    fclose(f);
-    return std::make_pair(true,retval);
-}
-
-/** Write contents of std::string to a file.
- * @return true on success.
- */
-bool WriteBinaryFileTor(const std::string &filename, const std::string &data)
-{
-    FILE *f = fopen(filename.c_str(), "wb");
-    if (f == NULL)
-        return false;
-    if (fwrite(data.data(), 1, data.size(), f) != data.size()) {
-        fclose(f);
-        return false;
-    }
-    fclose(f);
-    return true;
-}

--- a/src/util.h
+++ b/src/util.h
@@ -271,14 +271,4 @@ template <typename Callable> void TraceThread(const char* name,  Callable func)
 
 std::string CopyrightHolders(const std::string& strPrefix);
 
-
-
-std::pair<bool,std::string> ReadBinaryFileTor(const std::string &filename, size_t maxsize=std::numeric_limits<size_t>::max());
-
-
-/** Write contents of std::string to a file.
- * @return true on success.
- */
-bool WriteBinaryFileTor(const std::string &filename, const std::string &data);
-
 #endif // BITCOIN_UTIL_H


### PR DESCRIPTION
We currently have an option within Qt to enable TOR at the start page, via the `Anonymous communication with Tor` checkbox. When this checkbox is clicked, a `torsetting.dat` file is created within the datadir, which contains a single character `1`. This file is then checked for on startup and starts TOR with default settings should it be found.

The way that this is done is not consistent with the rest of the project: Settings are either considered as entries to the `conf` file, or are stored in QSettings for Qt, or both, with `conf` taking precedence in the latter case. 

This PR proposes making the TOR checkbox feature a conf setting, as `-torsetup`, with a corresponding Qt setting. As stated, the conf setting will override the Qt setting. The setting of the checkbox will also be based on this hierarchy. I've also removed relevant functions from `util.cpp` which are no longer needed.