### PR TITLE
Default fee reduction in Qt

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -55,7 +55,7 @@ static const bool DEFAULT_WHITELISTRELAY = true;
 static const bool DEFAULT_WHITELISTFORCERELAY = true;
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
 //btzc: update zcoin fee
-static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = CENT / 10; //0.001 zcoin,
+static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = CENT / 1000; //0.00001 zcoin,
 static const unsigned int MAX_STANDARD_TX_SIZE = 300000;
 //! -maxtxfee default
 static const CAmount DEFAULT_TRANSACTION_MAXFEE = 1000 * CENT;

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -103,7 +103,7 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *platformStyle, QWidget *pa
         settings.setValue("nTransactionFee", (qint64)DEFAULT_TRANSACTION_FEE);
     if (!settings.contains("fPayOnlyMinFee"))
         settings.setValue("fPayOnlyMinFee", false);
-    ui->customFee->setValue(CENT/10);
+    ui->customFee->setValue(DEFAULT_MIN_RELAY_TX_FEE);
     ui->checkBoxMinimumFee->setChecked(true);
     minimizeFeeSection(false);
 }


### PR DESCRIPTION
Change default fee per byte from 100 sat/byte to 1 sat/byte in Qt.

Fixes https://github.com/zcoinofficial/zcoin/issues/233