### PR TITLE
Fix gettransaction for mint/spend

### DIFF
--- a/qa/rpc-tests/zcoin_manymintspend.py
+++ b/qa/rpc-tests/zcoin_manymintspend.py
@@ -17,8 +17,7 @@ class ZcoinManyMintSpendTest(BitcoinTestFramework):
         return start_nodes(self.num_nodes, self.options.tmpdir)
 
     def run_test(self):
-        # Decimal formating: 6 digits for balance will be enought 000.000 
-        getcontext().prec = 6
+        getcontext().prec = 16
 
         # old denomination
         # TODO should be changed after RPC will be updated
@@ -35,11 +34,13 @@ class ZcoinManyMintSpendTest(BitcoinTestFramework):
             info = self.nodes[0].gettransaction(mint_trans[-1])
 
             # fee in transaction is negative
-            fee = -info['fee']
+            fee = info['fee']
+
+            # mint is treated as send to yourself so the balace will reduced by fee only
             cur_bal = self.nodes[0].getbalance()
-            start_bal = start_bal - Decimal(2*denom + fee)
+            start_bal += fee
             assert start_bal == cur_bal, \
-                'Unexpected current balance: {}, should be minus two mints and 1 fee, ' \
+                'Unexpected current balance: {}, should be minus mint fee, ' \
                 'but start was {}'.format(cur_bal, start_bal)
 
 
@@ -52,21 +53,21 @@ class ZcoinManyMintSpendTest(BitcoinTestFramework):
                 assert confrms == i, \
                     'Confirmations should be {}, '\
                     'due to {} blocks was generated after transaction was created,' \
-                    'but was {}'.format(i, i, confrms) 
+                    'but was {}'.format(i, i, confrms)
 
                 assert tr_type == 'mint', 'Unexpected transaction type'
             for denom in denoms:
                 res = False
-                try: 
+                try:
                     res = self.nodes[0].spendzerocoin(denom)
                 except JSONRPCException as ex:
                     assert ex.error['message'] == \
                         'it has to have at least two mint coins with at least 6 confirmation in order to spend a coin'
                 assert not res, 'Did not raise spend exception, but should be.'
-                
+
             self.nodes[0].generate(1)
             self.sync_all()
-        
+
         # generate last confirmation block - now all transactions should be confimed
         self.nodes[0].generate(1)
         self.sync_all()
@@ -78,15 +79,18 @@ class ZcoinManyMintSpendTest(BitcoinTestFramework):
             assert confrms == 6, \
                 'Confirmations should be 6, ' \
                 'due to 6 blocks was generated after transaction was created,' \
-                'but was {}.'.format(confrms) 
+                'but was {}.'.format(confrms)
             assert tr_type == 'mint', 'Unexpected transaction type'
 
         # Verify that now we are able to spend
-        spend_trans = list()  
-        spend_total = Decimal(0)        
+        spend_trans = list()
+        spend_total = Decimal(0)
         for denom in denoms:
             spend_trans.append(self.nodes[0].spendzerocoin(denom))
-            spend_total += denom
+
+            # this is send to yourself so the amount will be zero
+            info = self.nodes[0].gettransaction(spend_trans[-1])
+            spend_total += Decimal(info['fee'])
 
         # Verify, that after one confirmation balance will be updated on spends
         self.nodes[0].generate(1)

--- a/qa/rpc-tests/zcoin_mintmanyspend.py
+++ b/qa/rpc-tests/zcoin_mintmanyspend.py
@@ -76,8 +76,7 @@ class ZcoinMintSpendManyTest(BitcoinTestFramework):
 
             start_bal += fee
 
-        # Verify, that balance did not change, cause we did not confirm the operation
-        # Start balance increase on generated blocks to confirm
+        # Verify, that balance reduced correctly by spend fee
         start_bal += 40 * 6
         cur_bal = self.nodes[0].getbalance()
         assert start_bal == cur_bal, \

--- a/qa/rpc-tests/zcoin_mintspend.py
+++ b/qa/rpc-tests/zcoin_mintspend.py
@@ -17,8 +17,7 @@ class ZcoinMintSpendTest(BitcoinTestFramework):
         return start_nodes(self.num_nodes, self.options.tmpdir)
 
     def run_test(self):
-        # Decimal formating: 6 digits for balance will be enought 000.000 
-        getcontext().prec = 6
+        getcontext().prec = 16
 
         # old denomination
         # TODO should be changed after RPC will be updated
@@ -36,12 +35,13 @@ class ZcoinMintSpendTest(BitcoinTestFramework):
             info = self.nodes[0].gettransaction(mint_trans[-1])
 
             # fee in transaction is negative
-            fee = -info['fee']
+            fee = Decimal(info['fee'])
 
+            # mint is treated as send to yourself so the balace will reduced by fee only
             cur_bal = self.nodes[0].getbalance()
-            start_bal = start_bal - Decimal((denom + fee) * 2)
+            start_bal += fee*2
             assert start_bal == cur_bal, \
-                'Unexpected current balance: {}, should be minus two mints and two fee, ' \
+                'Unexpected current balance: {}, should be minus two fee, ' \
                 'but start was {}'.format(cur_bal, start_bal)
 
         # confirmations should be i due to less than 6 blocks was generated after transactions send
@@ -58,16 +58,16 @@ class ZcoinMintSpendTest(BitcoinTestFramework):
                 assert tr_type == 'mint', 'Unexpected transaction type'
             for denom in denoms:
                 res = False
-                try: 
+                try:
                     res = self.nodes[0].spendzerocoin(denom)
                 except JSONRPCException as ex:
                     assert ex.error['message'] == \
                         'it has to have at least two mint coins with at least 6 confirmation in order to spend a coin'
                 assert not res, 'Did not raise spend exception, but should be.'
-                
+
             self.nodes[0].generate(1)
             self.sync_all()
-        
+
         # generate last confirmation block - now all transactions should be confimed
         self.nodes[0].generate(1)
         self.sync_all()
@@ -82,8 +82,8 @@ class ZcoinMintSpendTest(BitcoinTestFramework):
                 'but was {}.'.format(confrms)
             assert tr_type == 'mint', 'Unexpected transaction type'
 
-        spend_trans = list()  
-        spend_total = Decimal(0)        
+        spend_trans = list()
+        spend_total = Decimal(0)
         for denom in denoms:
             spend_trans.append(self.nodes[0].spendzerocoin(denom))
             spend_total += denom
@@ -97,31 +97,25 @@ class ZcoinMintSpendTest(BitcoinTestFramework):
                 'but was {}.'.format(confrms)
             assert tr_type == 'spend', 'Unexpected transaction type'
 
+            # this is send to yourself so the amount will be zero
             spend_amount = Decimal(info['amount'])
-            exp_spend = Decimal(denom)
-            assert exp_spend == spend_amount, \
-                'Unexpected spend amount {}' \
-                ' but should be: {}.'.format(spend_amount, exp_spend)
+            fee = Decimal(info['fee'])
 
-        # Verify, that balance did not change, cause we did not confirm the operation
-        # Start balance increase on generated blocks to confirm
+            assert spend_amount == 0, \
+                'Unexpected spend amount {}' \
+                ' but should be: 0.'.format(spend_amount)
+
+            start_bal += fee
+
+        # Verify, that balance reduced correctly by spend fee
         start_bal += 40 * 6
         cur_bal = self.nodes[0].getbalance()
         assert start_bal == cur_bal, \
-            'Unexpected current balance: {}, should not change after spend, ' \
-            ' while we do not confirm, but start was {}'.format(cur_bal, start_bal)
+            'Unexpected current balance: {}'.format(cur_bal)
 
         # Verify, that after one confirmation balance will be updated on spends
         self.nodes[0].generate(1)
         self.sync_all()
-
-        # Start balance increase on generated blocks to confirm
-        start_bal += 40 * 1
-        cur_bal = self.nodes[0].getbalance()
-        start_bal = start_bal + spend_total
-        assert start_bal == cur_bal, \
-            'Unexpected current balance: {}, should increase on {}, ' \
-            'but start was {}'.format(cur_bal, spend_total, start_bal)
 
         for tr in spend_trans:
             info = self.nodes[0].gettransaction(tr)
@@ -131,7 +125,7 @@ class ZcoinMintSpendTest(BitcoinTestFramework):
             assert confrms == 1, \
                 'Confirmations should be 1, ' \
                 'due to 1 blocks was generated after transaction was created,' \
-                'but was {}.'.format(confrms) 
+                'but was {}.'.format(confrms)
             assert tr_type == 'spend', 'Unexpected transaction type'
 
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -11,9 +11,20 @@
 #include "serialize.h"
 #include "uint256.h"
 
+#include <exception>
+
 static const int SERIALIZE_TRANSACTION_NO_WITNESS = 0x40000000;
 
 static const int WITNESS_SCALE_FACTOR = 4;
+
+class CBadTxIn : public std::exception
+{
+};
+
+class CBadSequence : public CBadTxIn
+{
+};
+
 /** An outpoint - a combination of a transaction hash and an index n into its vout */
 class COutPoint
 {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -628,7 +628,7 @@ void WalletModel::listCoins(std::map<QString, std::vector<COutput> >& mapCoins) 
     {
         COutput cout = out;
 
-        while (wallet->IsChange(cout.tx->vout[cout.i]) && cout.tx->vin.size() > 0 && wallet->IsMine(cout.tx->vin[0]))
+        while (cout.tx->IsChange(static_cast<uint32_t>(cout.i)) && cout.tx->vin.size() > 0 && wallet->IsMine(cout.tx->vin[0]))
         {
             if (!wallet->mapWallet.count(cout.tx->vin[0].prevout.hash)) break;
             cout = COutput(&wallet->mapWallet[cout.tx->vin[0].prevout.hash], cout.tx->vin[0].prevout.n, 0, true, true);
@@ -693,7 +693,7 @@ bool WalletModel::transactionCanBeAbandoned(uint256 hash) const
 {
     LOCK2(cs_main, wallet->cs_wallet);
     const CWalletTx *wtx = wallet->GetWalletTx(hash);
-    if (!wtx || wtx->isAbandoned() || wtx->GetDepthInMainChain() > 0 || 
+    if (!wtx || wtx->isAbandoned() || wtx->GetDepthInMainChain() > 0 ||
         wtx->InMempool() || wtx->InStempool())
         return false;
     return true;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1379,11 +1379,11 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                 entry.push_back(Pair("involvesWatchonly", true));
             entry.push_back(Pair("account", strSentAccount));
             MaybePushAddress(entry, s.destination, addr);
-            if (wtx.IsZerocoinMint() || wtx.IsZerocoinMintV3()) {
-                entry.push_back(Pair("category", "mint"));
-            }
-            else if (wtx.IsZerocoinSpend() || wtx.IsZerocoinSpendV3()) {
+            if (wtx.IsZerocoinSpend() || wtx.IsZerocoinSpendV3()) {
                 entry.push_back(Pair("category", "spend"));
+            }
+            else if (wtx.IsZerocoinMint() || wtx.IsZerocoinMintV3()) {
+                entry.push_back(Pair("category", "mint"));
             }
             else {
                 entry.push_back(Pair("category", "send"));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1382,7 +1382,7 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
             if (wtx.IsZerocoinMint() || wtx.IsZerocoinMintV3()) {
                 entry.push_back(Pair("category", "mint"));
             }
-            else if(wtx.IsZerocoinSpend()){
+            else if (wtx.IsZerocoinSpend() || wtx.IsZerocoinSpendV3()) {
                 entry.push_back(Pair("category", "spend"));
             }
             else {
@@ -1434,12 +1434,6 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
                         entry.push_back(Pair("category", "immature"));
                     else
                         entry.push_back(Pair("category", "generate"));
-                }
-                else if(wtx.IsZerocoinSpend()){
-                    entry.push_back(Pair("category", "spend"));
-                }
-                else if(wtx.IsZerocoinSpendV3()){
-                    entry.push_back(Pair("category", "spend"));
                 }
                 else {
                     entry.push_back(Pair("category", "receive"));

--- a/src/wallet/txbuilder.cpp
+++ b/src/wallet/txbuilder.cpp
@@ -11,6 +11,7 @@
 #include <boost/format.hpp>
 
 #include <algorithm>
+#include <random>
 #include <stdexcept>
 #include <string>
 
@@ -141,7 +142,7 @@ CWalletTx TxBuilder::Build(const std::vector<CRecipient>& recipients, CAmount& f
                 outputs.push_back(std::make_pair(std::ref(output), true));
             }
 
-            std::shuffle(outputs.begin(), outputs.end(), []() { return GetRandInt(INT_MAX); });
+            std::shuffle(outputs.begin(), outputs.end(), std::random_device());
 
             // replace outputs with shuffled one
             std::vector<CTxOut> shuffled;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1736,7 +1736,8 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache) const {
     if (IsCoinBase() && GetBlocksToMaturity() > 0)
         return 0;
 
-    if (fUseCache && fAvailableCreditCached)
+    // We cannot use cache if vout contains mints due to it will not update when it spend
+    if (fUseCache && fAvailableCreditCached && !IsZerocoinMint() && !IsZerocoinMintV3())
         return nAvailableCreditCached;
 
     CAmount nCredit = 0;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1823,7 +1823,9 @@ bool CWalletTx::IsChange(uint32_t out) const {
     }
 
     // Legacy transaction handling.
-    if (::IsMine(*pwallet, vout[out].scriptPubKey)) {
+    // Zerocoin spend have one special output mode to spend to yourself with change address,
+    // we don't want to identify that output as change.
+    if (!IsZerocoinSpend() && ::IsMine(*pwallet, vout[out].scriptPubKey)) {
         CTxDestination address;
         if (!ExtractDestination(vout[out].scriptPubKey, address)) {
             return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2504,6 +2504,10 @@ void CWallet::AvailableCoins(vector <COutput> &vCoins, bool fOnlyConfirmed, cons
                 continue;
 
             for (unsigned int i = 0; i < pcoin->vout.size(); i++) {
+                if (pcoin->vout[i].scriptPubKey.IsZerocoinMint() || pcoin->vout[i].scriptPubKey.IsZerocoinMintV3()) {
+                    continue;
+                }
+
                 bool found = false;
                 if (nCoinType == ONLY_DENOMINATED) {
                     found = IsDenominatedAmount(pcoin->vout[i].nValue);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -590,7 +590,7 @@ void CWallet::AddToSpends(const uint256 &wtxid) {
         return;
 
     for (const CTxIn &txin : thisTx.vin) {
-        if (!txin.IsZerocoinSpend() && !txin.IsZerocoinSpend()) {
+        if (!txin.IsZerocoinSpend() && !txin.IsZerocoinSpendV3()) {
             AddToSpends(txin.prevout, wtxid);
         }
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1175,6 +1175,10 @@ CAmount CWallet::GetDebit(const CTxIn &txin, const isminefilter &filter) const {
     LOCK(cs_wallet);
 
     if (txin.IsZerocoinSpend()) {
+        if (!(filter & ISMINE_SPENDABLE)) {
+            goto end;
+        }
+
         CWalletDB db(strWalletFile);
         std::unique_ptr<libzerocoin::CoinSpend> spend;
 
@@ -1188,6 +1192,10 @@ CAmount CWallet::GetDebit(const CTxIn &txin, const isminefilter &filter) const {
             return spend->getDenomination() * COIN;
         }
     } else if (txin.IsZerocoinSpendV3()) {
+        if (!(filter & ISMINE_SPENDABLE)) {
+            goto end;
+        }
+
         CWalletDB db(strWalletFile);
         std::unique_ptr<sigma::CoinSpendV3> spend;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -277,6 +277,7 @@ public:
     char fFromMe;
     std::string strFromAccount;
     int64_t nOrderPos; //!< position in ordered transaction list
+    std::unordered_set<uint32_t> changes; //!< positions of changes in vout
 
     // memory only
     mutable bool fDebitCached;
@@ -347,19 +348,27 @@ public:
         nImmatureWatchCreditCached = 0;
         nChangeCached = 0;
         nOrderPos = -1;
+        changes.clear();
     }
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        constexpr uint32_t FLAG_WITH_CHANGES = 0x00000001;
+
         if (ser_action.ForRead())
             Init(NULL);
+
         char fSpent = false;
+        uint32_t flags = 0;
 
         if (!ser_action.ForRead())
         {
+            flags = FLAG_WITH_CHANGES;
+
             mapValue["fromaccount"] = strFromAccount;
+            mapValue["flags"] = strprintf("0x%x", flags);
 
             WriteOrderPos(nOrderPos, mapValue);
 
@@ -384,6 +393,15 @@ public:
             ReadOrderPos(nOrderPos, mapValue);
 
             nTimeSmart = mapValue.count("timesmart") ? (unsigned int)atoi64(mapValue["timesmart"]) : 0;
+
+            auto it = mapValue.find("flags");
+            if (it != mapValue.end()) {
+                flags = static_cast<uint32_t>(std::strtoul(it->second.c_str(), nullptr, 0));
+            }
+        }
+
+        if (flags & FLAG_WITH_CHANGES) {
+            READWRITE(changes);
         }
 
         mapValue.erase("fromaccount");
@@ -391,6 +409,7 @@ public:
         mapValue.erase("spent");
         mapValue.erase("n");
         mapValue.erase("timesmart");
+        mapValue.erase("flags");
     }
 
     //! make sure balances are recalculated
@@ -439,6 +458,9 @@ public:
     bool InMempool() const;
     bool InStempool() const;
     bool IsTrusted() const;
+
+    bool IsChange(uint32_t out) const;
+    bool IsChange(const CTxOut& out) const;
 
     int64_t GetTxTime() const;
     int GetRequestCount() const;
@@ -1012,8 +1034,8 @@ public:
     CAmount GetDebit(const CTxIn& txin, const isminefilter& filter) const;
     isminetype IsMine(const CTxOut& txout) const;
     CAmount GetCredit(const CTxOut& txout, const isminefilter& filter) const;
-    bool IsChange(const CTxOut& txout) const;
-    CAmount GetChange(const CTxOut& txout) const;
+    bool IsChange(const uint256& tx, const CTxOut& txout) const;
+    CAmount GetChange(const uint256& tx, const CTxOut& txout) const;
     bool IsMine(const CTransaction& tx) const;
     /** should probably be renamed to IsRelevantToMe */
     bool IsFromMe(const CTransaction& tx) const;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -274,6 +274,14 @@ bool CWalletDB::WriteZerocoinEntry(const CZerocoinEntryV3 &zerocoin) {
     return Write(std::make_pair(std::string("sigma_mint"), zerocoin.value), zerocoin, true);
 }
 
+bool CWalletDB::ReadZerocoinEntry(const Bignum& pub, CZerocoinEntry& entry) {
+    return Read(std::make_pair(std::string("zerocoin"), pub), entry);
+}
+
+bool CWalletDB::ReadZerocoinEntry(const secp_primitives::GroupElement& pub, CZerocoinEntryV3& entry) {
+    return Read(std::make_pair(std::string("sigma_mint"), pub), entry);
+}
+
 bool CWalletDB::HasZerocoinEntry(const Bignum& pub) {
     return Exists(std::make_pair(std::string("zerocoin"), pub));
 }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -230,7 +230,15 @@ bool CWalletDB::WriteCoinSpendSerialEntry(const CZerocoinSpendEntry &zerocoinSpe
 }
 
 bool CWalletDB::WriteCoinSpendSerialEntry(const CZerocoinSpendEntryV3 &zerocoinSpend) {
-    return Write(make_pair(string("zcserial_sigma"), zerocoinSpend.coinSerial), zerocoinSpend, true);
+    return Write(std::make_pair(std::string("sigma_spend"), zerocoinSpend.coinSerial), zerocoinSpend, true);
+}
+
+bool CWalletDB::HasCoinSpendSerialEntry(const Bignum& serial) {
+    return Exists(std::make_pair(std::string("zcserial"), serial));
+}
+
+bool CWalletDB::HasCoinSpendSerialEntry(const secp_primitives::Scalar& serial) {
+    return Exists(std::make_pair(std::string("sigma_spend"), serial));
 }
 
 bool CWalletDB::EraseCoinSpendSerialEntry(const CZerocoinSpendEntry &zerocoinSpend) {
@@ -238,7 +246,7 @@ bool CWalletDB::EraseCoinSpendSerialEntry(const CZerocoinSpendEntry &zerocoinSpe
 }
 
 bool CWalletDB::EraseCoinSpendSerialEntry(const CZerocoinSpendEntryV3 &zerocoinSpend) {
-    return Erase(make_pair(string("zcserial_sigma"), zerocoinSpend.coinSerial));
+    return Erase(std::make_pair(std::string("sigma_spend"), zerocoinSpend.coinSerial));
 }
 
 bool
@@ -263,11 +271,19 @@ bool CWalletDB::WriteZerocoinEntry(const CZerocoinEntry &zerocoin) {
 }
 
 bool CWalletDB::WriteZerocoinEntry(const CZerocoinEntryV3 &zerocoin) {
-    return Write(make_pair(string("zerocoin_sigma"), zerocoin.value), zerocoin, true);
+    return Write(std::make_pair(std::string("sigma_mint"), zerocoin.value), zerocoin, true);
+}
+
+bool CWalletDB::HasZerocoinEntry(const Bignum& pub) {
+    return Exists(std::make_pair(std::string("zerocoin"), pub));
+}
+
+bool CWalletDB::HasZerocoinEntry(const secp_primitives::GroupElement& pub) {
+    return Exists(std::make_pair(std::string("sigma_mint"), pub));
 }
 
 bool CWalletDB::EraseZerocoinEntry(const CZerocoinEntryV3 &zerocoin) {
-    return Erase(make_pair(string("zerocoin_sigma"), zerocoin.value));
+    return Erase(std::make_pair(std::string("sigma_mint"), zerocoin.value));
 }
 
 bool CWalletDB::EraseZerocoinEntry(const CZerocoinEntry &zerocoin) {
@@ -326,7 +342,7 @@ void CWalletDB::ListPubCoinV3(std::list <CZerocoinEntryV3> &listPubCoin) {
         // Read next record
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         if (fFlags == DB_SET_RANGE)
-            ssKey << make_pair(string("zerocoin_sigma"), GroupElement());
+            ssKey << std::make_pair(std::string("sigma_mint"), secp_primitives::GroupElement());
         CDataStream ssValue(SER_DISK, CLIENT_VERSION);
         int ret = ReadAtCursor(pcursor, ssKey, ssValue, fFlags);
         fFlags = DB_NEXT;
@@ -339,7 +355,7 @@ void CWalletDB::ListPubCoinV3(std::list <CZerocoinEntryV3> &listPubCoin) {
         // Unserialize
         string strType;
         ssKey >> strType;
-        if (strType != "zerocoin_sigma")
+        if (strType != "sigma_mint")
             break;
         GroupElement value;
         ssKey >> value;
@@ -394,7 +410,7 @@ void CWalletDB::ListCoinSpendSerial(std::list <CZerocoinSpendEntryV3> &listCoinS
         // Read next record
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         if (fFlags == DB_SET_RANGE)
-            ssKey << make_pair(string("zcserial_sigma"), GroupElement());
+            ssKey << std::make_pair(std::string("sigma_spend"), secp_primitives::GroupElement());
         CDataStream ssValue(SER_DISK, CLIENT_VERSION);
         int ret = ReadAtCursor(pcursor, ssKey, ssValue, fFlags);
         fFlags = DB_NEXT;
@@ -408,7 +424,7 @@ void CWalletDB::ListCoinSpendSerial(std::list <CZerocoinSpendEntryV3> &listCoinS
         // Unserialize
         string strType;
         ssKey >> strType;
-        if (strType != "zcserial_sigma")
+        if (strType != "sigma_spend")
             break;
         Scalar value;
         ssKey >> value;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -12,6 +12,9 @@
 #include "wallet/db.h"
 #include "key.h"
 
+#include "../secp256k1/include/GroupElement.h"
+#include "../secp256k1/include/Scalar.h"
+
 #include <list>
 #include <stdint.h>
 #include <string>

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -175,6 +175,8 @@ public:
 
     bool WriteZerocoinEntry(const CZerocoinEntry& zerocoin);
     bool WriteZerocoinEntry(const CZerocoinEntryV3& zerocoin);
+    bool HasZerocoinEntry(const Bignum& pub);
+    bool HasZerocoinEntry(const secp_primitives::GroupElement& pub);
     bool EraseZerocoinEntry(const CZerocoinEntry& zerocoin);
     bool EraseZerocoinEntry(const CZerocoinEntryV3& zerocoin);
     void ListPubCoin(std::list<CZerocoinEntry>& listPubCoin);
@@ -183,6 +185,8 @@ public:
     void ListCoinSpendSerial(std::list<CZerocoinSpendEntryV3>& listCoinSpendSerial);
     bool WriteCoinSpendSerialEntry(const CZerocoinSpendEntry& zerocoinSpend);
     bool WriteCoinSpendSerialEntry(const CZerocoinSpendEntryV3& zerocoinSpend);
+    bool HasCoinSpendSerialEntry(const Bignum& serial);
+    bool HasCoinSpendSerialEntry(const secp_primitives::Scalar& serial);
     bool EraseCoinSpendSerialEntry(const CZerocoinSpendEntry& zerocoinSpend);
     bool EraseCoinSpendSerialEntry(const CZerocoinSpendEntryV3& zerocoinSpend);
     bool WriteZerocoinAccumulator(libzerocoin::Accumulator accumulator, libzerocoin::CoinDenomination denomination, int pubcoinid);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -178,6 +178,8 @@ public:
 
     bool WriteZerocoinEntry(const CZerocoinEntry& zerocoin);
     bool WriteZerocoinEntry(const CZerocoinEntryV3& zerocoin);
+    bool ReadZerocoinEntry(const Bignum& pub, CZerocoinEntry& entry);
+    bool ReadZerocoinEntry(const secp_primitives::GroupElement& pub, CZerocoinEntryV3& entry);
     bool HasZerocoinEntry(const Bignum& pub);
     bool HasZerocoinEntry(const secp_primitives::GroupElement& pub);
     bool EraseZerocoinEntry(const CZerocoinEntry& zerocoin);

--- a/src/zerocoin.h
+++ b/src/zerocoin.h
@@ -45,6 +45,9 @@ public:
     void Complete();
 };
 
+CBigNum ParseZerocoinMintScript(const CScript& script);
+std::pair<std::unique_ptr<libzerocoin::CoinSpend>, uint32_t> ParseZerocoinSpend(const CTxIn& in);
+
 bool CheckZerocoinFoundersInputs(const CTransaction &tx, CValidationState &state, const Consensus::Params &params, int nHeight, bool fMTP);
 bool CheckZerocoinTransaction(const CTransaction &tx,
 	CValidationState &state,

--- a/src/zerocoin_v3.cpp
+++ b/src/zerocoin_v3.cpp
@@ -51,6 +51,39 @@ static bool CheckZerocoinSpendSerialV3(
 	return true;
 }
 
+secp_primitives::GroupElement ParseSigmaMintScript(const CScript& script)
+{
+	if (script.size() < 1) {
+		throw std::invalid_argument("Script is not a valid Sigma mint");
+	}
+
+	std::vector<unsigned char> serialized(script.begin() + 1, script.end());
+
+	secp_primitives::GroupElement pub;
+	pub.deserialize(serialized.data());
+
+	return pub;
+}
+
+std::pair<std::unique_ptr<sigma::CoinSpendV3>, uint32_t> ParseSigmaSpend(const CTxIn& in)
+{
+	uint32_t groupId = in.prevout.n;
+
+	if (groupId < 1 || groupId >= INT_MAX || in.scriptSig.size() < 1) {
+		throw CBadTxIn();
+	}
+
+	CDataStream serialized(
+		std::vector<unsigned char>(in.scriptSig.begin() + 1, in.scriptSig.end()),
+		SER_NETWORK,
+		PROTOCOL_VERSION
+	);
+
+	std::unique_ptr<sigma::CoinSpendV3> spend(new sigma::CoinSpendV3(ZCParamsV3, serialized));
+
+	return std::make_pair(std::move(spend), groupId);
+}
+
 // This function will not report an error only if the transaction is zerocoin spend V3.
 // Will return false for V1, V1.5 and V2 spends.
 // Mixing V2 and V3 spends into the same transaction will fail.
@@ -67,39 +100,27 @@ bool CheckSpendZcoinTransactionV3(
 	bool hasZerocoinSpendInputs = false, hasNonZerocoinInputs = false;
 	int vinIndex = -1;
 
-	BOOST_FOREACH(const CTxIn &txin, tx.vin)
+	for (const CTxIn &txin : tx.vin)
 	{
+		std::unique_ptr<sigma::CoinSpendV3> spend;
+		uint32_t pubcoinId;
+
 		vinIndex++;
 		if (txin.scriptSig.IsZerocoinSpendV3())
 			hasZerocoinSpendInputs = true;
 		else
 			hasNonZerocoinInputs = true;
 
-		uint32_t pubcoinId = txin.prevout.n;
-		if (pubcoinId < 1 || pubcoinId >= INT_MAX) {
-			// coin id should be positive integer
+		try {
+			std::tie(spend, pubcoinId) = ParseSigmaSpend(txin);
+		} catch (CBadTxIn&) {
 			return state.DoS(100,
-					false,
-					NSEQUENCE_INCORRECT,
-					"CTransaction::CheckTransaction() : Error: zerocoin spend nSequence is incorrect");
+				false,
+				REJECT_MALFORMED,
+				"CheckSpendZcoinTransactionV3: invalid spend transaction");
 		}
 
-		if (txin.scriptSig.size() < 4)
-			return state.DoS(100,
-					false,
-					REJECT_MALFORMED,
-					"CheckSpendZcoinTransactionV3: invalid spend transaction");
-
-		// Deserialize the CoinSpend into a fresh object
-        // NOTE(martun): +1 on the next line stands for 1 byte in which the opcode of
-        // OP_ZEROCOINSPENDV3 is written. In zerocoin you will see +4 instead,
-        // because the size of serialized spend is also written, probably in 3 bytes.
-		CDataStream serializedCoinSpend((const char *)&*(txin.scriptSig.begin() + 1),
-				(const char *)&*txin.scriptSig.end(),
-				SER_NETWORK, PROTOCOL_VERSION);
-		sigma::CoinSpendV3 newSpend(ZCParamsV3, serializedCoinSpend);
-
-		if (newSpend.getVersion() != ZEROCOIN_TX_VERSION_3) {
+		if (spend->getVersion() != ZEROCOIN_TX_VERSION_3) {
 			return state.DoS(100,
 							 false,
 							 NSEQUENCE_INCORRECT,
@@ -118,8 +139,8 @@ bool CheckSpendZcoinTransactionV3(
 		txHashForMetadata = txTemp.GetHash();
 
 		LogPrintf("CheckSpendZcoinTransactionV3: tx version=%d, tx metadata hash=%s, serial=%s\n",
-				newSpend.getVersion(), txHashForMetadata.ToString(),
-				newSpend.getCoinSerialNumber().tostring());
+				spend->getVersion(), txHashForMetadata.ToString(),
+				spend->getCoinSerialNumber().tostring());
 
 		CZerocoinStateV3::CoinGroupInfoV3 coinGroup;
 		if (!zerocoinStateV3.GetCoinGroupInfo(targetDenominations[vinIndex], pubcoinId, coinGroup))
@@ -131,7 +152,7 @@ bool CheckSpendZcoinTransactionV3(
 		pair<sigma::CoinDenominationV3, int> denominationAndId = std::make_pair(
             targetDenominations[vinIndex], pubcoinId);
 
-		uint256 accumulatorBlockHash = newSpend.getAccumulatorBlockHash();
+		uint256 accumulatorBlockHash = spend->getAccumulatorBlockHash();
 
         // We use incomplete transaction hash as metadata.
         sigma::SpendMetaDataV3 newMetaData(
@@ -157,9 +178,9 @@ bool CheckSpendZcoinTransactionV3(
 			index = index->pprev;
         }
 
-		passVerify = newSpend.Verify(anonymity_set, newMetaData);
+		passVerify = spend->Verify(anonymity_set, newMetaData);
 		if (passVerify) {
-			Scalar serial = newSpend.getCoinSerialNumber();
+			Scalar serial = spend->getCoinSerialNumber();
 			// do not check for duplicates in case we've seen exact copy of this tx in this block before
 			if (!(zerocoinTxInfoV3 && zerocoinTxInfoV3->zcTransactions.count(hashTx) > 0)) {
 				if (!CheckZerocoinSpendSerialV3(
@@ -171,7 +192,7 @@ bool CheckSpendZcoinTransactionV3(
 				if (zerocoinTxInfoV3 && !zerocoinTxInfoV3->fInfoIsComplete) {
 					// add spend information to the index
 					zerocoinTxInfoV3->spentSerials.insert(std::make_pair(
-								serial, (int)newSpend.getDenomination()));
+								serial, (int)spend->getDenomination()));
 					zerocoinTxInfoV3->zcTransactions.insert(hashTx);
 				}
 			}
@@ -200,21 +221,19 @@ bool CheckMintZcoinTransactionV3(
 		CValidationState &state,
 		uint256 hashTx,
 		CZerocoinTxInfoV3 *zerocoinTxInfoV3) {
+	secp_primitives::GroupElement pubCoinValue;
+
 	LogPrintf("CheckMintZcoinTransactionV3 txHash = %s\n", txout.GetHash().ToString());
 	LogPrintf("nValue = %d\n", txout.nValue);
 
-	if (txout.scriptPubKey.size() < 4)
+	try {
+		pubCoinValue = ParseSigmaMintScript(txout.scriptPubKey);
+	} catch (std::invalid_argument&) {
 		return state.DoS(100,
-				false,
-				PUBCOIN_NOT_VALIDATE,
-				"CTransaction::CheckTransactionV3() : PubCoin validation failed");
-
-    // If you wonder why +1, go to file wallet.cpp and read the comments in function
-    // CWallet::CreateZerocoinMintModelV3 around "scriptSerializedCoin << OP_ZEROCOINMINTV3";
-	vector<unsigned char> coin_serialised(txout.scriptPubKey.begin() + 1,
-                                          txout.scriptPubKey.end());
-	secp_primitives::GroupElement pubCoinValue;
-	pubCoinValue.deserialize(&coin_serialised[0]);
+			false,
+			PUBCOIN_NOT_VALIDATE,
+			"CTransaction::CheckTransactionV3() : PubCoin validation failed");
+	}
 
 	sigma::CoinDenominationV3 denomination;
     if (!IntegerToDenomination(txout.nValue, denomination, state)) {

--- a/src/zerocoin_v3.h
+++ b/src/zerocoin_v3.h
@@ -4,6 +4,7 @@
 #include "amount.h"
 #include "chain.h"
 #include "sigma/coin.h"
+#include "sigma/coinspend.h"
 #include "consensus/validation.h"
 #include <secp256k1/include/Scalar.h>
 #include <secp256k1/include/GroupElement.h>

--- a/src/zerocoin_v3.h
+++ b/src/zerocoin_v3.h
@@ -27,7 +27,7 @@ public:
 
     // Vector of <pubCoin> for all the mints.
     std::vector<PublicCoinV3> mints;
-  
+
     // serial for every spend (map from serial to denomination)
     std::unordered_map<Scalar, int, sigma::CScalarHash> spentSerials;
 
@@ -39,6 +39,9 @@ public:
     // finalize everything
     void Complete();
 };
+
+secp_primitives::GroupElement ParseSigmaMintScript(const CScript& script);
+std::pair<std::unique_ptr<sigma::CoinSpendV3>, uint32_t> ParseSigmaSpend(const CTxIn& in);
 
 bool CheckZerocoinTransactionV3(
   const CTransaction &tx,
@@ -52,10 +55,10 @@ bool CheckZerocoinTransactionV3(
 void DisconnectTipZCV3(CBlock &block, CBlockIndex *pindexDelete);
 
 bool ConnectBlockZCV3(
-  CValidationState& state, 
-  const CChainParams& chainparams, 
-  CBlockIndex* pindexNew, 
-  const CBlock *pblock, 
+  CValidationState& state,
+  const CChainParams& chainparams,
+  CBlockIndex* pindexNew,
+  const CBlock *pblock,
   bool fJustCheck=false);
 
 bool ZerocoinBuildStateFromIndexV3(CChain *chain);
@@ -82,7 +85,7 @@ public:
 
     struct CMintedCoinInfo {
         sigma::CoinDenominationV3 denomination;
-        
+
         // ID of coin group.
         int id;
         int nHeight;
@@ -101,7 +104,7 @@ public:
 
     // Add mint, automatically assigning id to it. Returns id and previous accumulator value (if any)
     int AddMint(
-        CBlockIndex *index, 
+        CBlockIndex *index,
         const PublicCoinV3& pubCoin);
 
     // Add serial to the list of used ones
@@ -127,11 +130,11 @@ public:
     // Do not take into account coins with height more than maxHeight
     // Returns number of coins satisfying conditions
     int GetCoinSetForSpend(
-        CChain *chain, 
-        int maxHeight, 
-        sigma::CoinDenominationV3 denomination, 
-        int id, 
-        uint256& blockHash_out, 
+        CChain *chain,
+        int maxHeight,
+        sigma::CoinDenominationV3 denomination,
+        int id,
+        uint256& blockHash_out,
         std::vector<PublicCoinV3>& coins_out);
 
     // Return height of mint transaction and id of minted coin
@@ -165,7 +168,7 @@ public:
     // Collection of coin groups. Map from <denomination,id> to CoinGroupInfoV3 structure
     std::unordered_map<pair<sigma::CoinDenominationV3, int>, CoinGroupInfoV3, pairhash> coinGroups;
 
-    // Set of all minted pubCoin values, keyed by the public coin. 
+    // Set of all minted pubCoin values, keyed by the public coin.
     // Used for checking if the given coin already exists.
     unordered_map<PublicCoinV3, CMintedCoinInfo, sigma::CPublicCoinHash> mintedPubCoins;
 


### PR DESCRIPTION
Once the code in this PR run the `wallet.dat` will not able to open with old client anymore. `wallet.dat` from previous version can open by this PR.

This PR is already reviewed so don't need to review again.