### PR TITLE
Get rid of a compilation warning

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -948,7 +948,7 @@ WalletModel::SendCoinsReturn WalletModel::sendSigma(WalletModelTransaction &tran
     return SendCoinsReturn(OK);
 }
 
-bool WalletModel::sigmaMint(const CAmount& n)
+void WalletModel::sigmaMint(const CAmount& n)
 {
     std::vector<sigma::CoinDenominationV3> denominations;
     sigma::GetAllDenoms(denominations);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -218,7 +218,7 @@ public:
         std::vector<CZerocoinEntryV3>& coins, std::vector<CZerocoinEntryV3>& changes);
 
     // Mint sigma
-    bool sigmaMint(const CAmount& n);
+    void sigmaMint(const CAmount& n);
     void checkSigmaAmount(bool forced);
 
 


### PR DESCRIPTION
qt/walletmodel.cpp: In member function ‘bool WalletModel::sigmaMint(const CAmount&)’:
qt/walletmodel.cpp:977:1: warning: control reaches end of non-void function [-Wreturn-type]
