### PR TITLE
Update zmq to 4.3.1

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,13 +1,20 @@
 package=zeromq
-$(package)_version=4.1.4
-$(package)_download_path=http://download.zeromq.org
+$(package)_version=4.3.1
+$(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=e99f44fde25c2e4cb84ce440f87ca7d3fe3271c2b8cfbc67d55e4de25e6fe378
+$(package)_sha256_hash=bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb
+$(package)_patches=0001-fix-build-with-older-mingw64.patch 0002-disable-pthread_set_name_np.patch
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-documentation --disable-shared --without-libsodium
+  $(package)_config_opts=--without-docs --disable-shared --without-libsodium --disable-curve --disable-curve-keygen --disable-perf --disable-Werror
   $(package)_config_opts_linux=--with-pic
   $(package)_cxxflags=-std=c++11
+endef
+
+define $(package)_preprocess_cmds
+   patch -p1 < $($(package)_patch_dir)/0001-fix-build-with-older-mingw64.patch && \
+   patch -p1 < $($(package)_patch_dir)/0002-disable-pthread_set_name_np.patch && \
+   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub config
 endef
 
 define $(package)_config_cmds
@@ -15,7 +22,7 @@ define $(package)_config_cmds
 endef
 
 define $(package)_build_cmds
-  $(MAKE) libzmq.la
+  $(MAKE) src/libzmq.la
 endef
 
 define $(package)_stage_cmds
@@ -23,5 +30,6 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
+  sed -i.old "s/ -lstdc++//" lib/pkgconfig/libzmq.pc && \
   rm -rf bin share
 endef

--- a/depends/patches/zeromq/0001-fix-build-with-older-mingw64.patch
+++ b/depends/patches/zeromq/0001-fix-build-with-older-mingw64.patch
@@ -1,0 +1,30 @@
+From f6866b0f166ad168618aae64c7fbee8775d3eb23 Mon Sep 17 00:00:00 2001
+From: mruddy <6440430+mruddy@users.noreply.github.com>
+Date: Sat, 30 Jun 2018 09:44:58 -0400
+Subject: [PATCH] fix build with older mingw64
+
+---
+ src/windows.hpp | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/src/windows.hpp b/src/windows.hpp
+index 6c3839fd..2c32ec79 100644
+--- a/src/windows.hpp
++++ b/src/windows.hpp
+@@ -58,6 +58,13 @@
+ #include <winsock2.h>
+ #include <windows.h>
+ #include <mswsock.h>
++
++#if defined __MINGW64_VERSION_MAJOR && __MINGW64_VERSION_MAJOR < 4
++// Workaround for mingw-w64 < v4.0 which did not include ws2ipdef.h in iphlpapi.h.
++// Fixed in mingw-w64 by 9bd8fe9148924840d315b4c915dd099955ea89d1.
++#include <ws2def.h>
++#include <ws2ipdef.h>
++#endif
+ #include <iphlpapi.h>
+ 
+ #if !defined __MINGW32__
+-- 
+2.17.1
+

--- a/depends/patches/zeromq/0002-disable-pthread_set_name_np.patch
+++ b/depends/patches/zeromq/0002-disable-pthread_set_name_np.patch
@@ -1,0 +1,35 @@
+From c9bbdd6581d07acfe8971e4bcebe278a3676cf03 Mon Sep 17 00:00:00 2001
+From: mruddy <6440430+mruddy@users.noreply.github.com>
+Date: Sat, 30 Jun 2018 09:57:18 -0400
+Subject: [PATCH] disable pthread_set_name_np
+
+pthread_set_name_np adds a Glibc requirement on >= 2.12.
+---
+ src/thread.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/thread.cpp b/src/thread.cpp
+index a1086b0c..9943f354 100644
+--- a/src/thread.cpp
++++ b/src/thread.cpp
+@@ -307,7 +307,7 @@ void zmq::thread_t::setThreadName (const char *name_)
+  */
+     if (!name_)
+         return;
+-
++#if 0
+ #if defined(ZMQ_HAVE_PTHREAD_SETNAME_1)
+     int rc = pthread_setname_np (name_);
+     if (rc)
+@@ -323,6 +323,8 @@ void zmq::thread_t::setThreadName (const char *name_)
+ #elif defined(ZMQ_HAVE_PTHREAD_SET_NAME)
+     pthread_set_name_np (descriptor, name_);
+ #endif
++#endif
++    return;
+ }
+ 
+ #endif
+-- 
+2.17.1
+

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -47,7 +47,7 @@ Optional dependencies:
  protobuf    | Payments in GUI  | Data interchange format used for payment protocol (only needed when GUI enabled)
  libqrencode | QR codes in GUI  | Optional for generating QR codes (only needed when GUI enabled)
  univalue    | Utility          | JSON parsing and encoding (bundled version will be used unless --with-system-univalue passed to configure)
- libzmq3     | ZMQ notification | Optional, allows generating ZMQ notifications (requires ZMQ version >= 4.x)
+ libzmq3     | ZMQ notification | Optional, allows generating ZMQ notifications (requires ZMQ version >= 4.0.0)
 
 For the versions used in the release, see [release-process.md](release-process.md) under *Fetch and build inputs*.
 
@@ -98,7 +98,7 @@ Optional:
 
     sudo apt-get install libminiupnpc-dev (see --with-miniupnpc and --enable-upnp-default)
 
-ZMQ dependencies:
+ZMQ dependencies (provides ZMQ API):
 
     sudo apt-get install libzmq3-dev (provides ZMQ API 4.x)
 

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -33,8 +33,10 @@ buffering or reassembly.
 
 ## Prerequisites
 
-The ZeroMQ feature in Bitcoin Core requires ZeroMQ API version 4.x or
-newer. Typically, it is packaged by distributions as something like
+The ZeroMQ feature in Bitcoin Core requires the ZeroMQ API >= 4.0.0
+[libzmq](https://github.com/zeromq/libzmq/releases).
+For version information, see [dependencies.md](dependencies.md).
+Typically, it is packaged by distributions as something like
 *libzmq3-dev*. The C++ wrapper for ZeroMQ is *not* needed.
 
 In order to run the example Python client scripts in contrib/ one must

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -72,10 +72,14 @@ CZMQNotificationInterface* CZMQNotificationInterface::CreateWithArguments(const 
 // Called at startup to conditionally set up ZMQ socket(s)
 bool CZMQNotificationInterface::Initialize()
 {
+    int major = 0, minor = 0, patch = 0;
+    zmq_version(&major, &minor, &patch);
+    LogPrint("zmq", "zmq: version %d.%d.%d\n", major, minor, patch);
+
     LogPrint("zmq", "zmq: Initialize notification interface\n");
     assert(!pcontext);
 
-    pcontext = zmq_init(1);
+    pcontext = zmq_ctx_new();
 
     if (!pcontext)
     {
@@ -118,7 +122,7 @@ void CZMQNotificationInterface::Shutdown()
             LogPrint("zmq", "   Shutdown notifier %s at %s\n", notifier->GetType(), notifier->GetAddress());
             notifier->Shutdown();
         }
-        zmq_ctx_destroy(pcontext);
+        zmq_ctx_term(pcontext);
 
         pcontext = 0;
     }


### PR DESCRIPTION
Addresses https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6250
Credit @Archimedes1618: "although the version you use is lower than the affected ones,  it might be worth thinking about using a newer version"
This is the same version Bitcoin now uses