### PR TITLE
Fix getbalance to return only non-mints output

### DIFF
--- a/qa/rpc-tests/zcoin_manymintspend.py
+++ b/qa/rpc-tests/zcoin_manymintspend.py
@@ -38,7 +38,7 @@ class ZcoinManyMintSpendTest(BitcoinTestFramework):
 
             # mint is treated as send to yourself so the balace will reduced by fee only
             cur_bal = self.nodes[0].getbalance()
-            start_bal += fee
+            start_bal += fee - 2 * denom
             assert start_bal == cur_bal, \
                 'Unexpected current balance: {}, should be minus mint fee, ' \
                 'but start was {}'.format(cur_bal, start_bal)
@@ -90,7 +90,7 @@ class ZcoinManyMintSpendTest(BitcoinTestFramework):
 
             # this is send to yourself so the amount will be zero
             info = self.nodes[0].gettransaction(spend_trans[-1])
-            spend_total += Decimal(info['fee'])
+            spend_total += Decimal(info['fee']) + denom
 
         # Verify, that after one confirmation balance will be updated on spends
         self.nodes[0].generate(1)

--- a/qa/rpc-tests/zcoin_mintspend.py
+++ b/qa/rpc-tests/zcoin_mintspend.py
@@ -39,7 +39,7 @@ class ZcoinMintSpendTest(BitcoinTestFramework):
 
             # mint is treated as send to yourself so the balace will reduced by fee only
             cur_bal = self.nodes[0].getbalance()
-            start_bal += fee*2
+            start_bal += 2 * fee - 2 * denom
             assert start_bal == cur_bal, \
                 'Unexpected current balance: {}, should be minus two fee, ' \
                 'but start was {}'.format(cur_bal, start_bal)
@@ -109,6 +109,7 @@ class ZcoinMintSpendTest(BitcoinTestFramework):
 
         # Verify, that balance reduced correctly by spend fee
         start_bal += 40 * 6
+        start_bal += spend_total
         cur_bal = self.nodes[0].getbalance()
         assert start_bal == cur_bal, \
             'Unexpected current balance: {}'.format(cur_bal)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1745,7 +1745,8 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache) const {
     for (unsigned int i = 0; i < vout.size(); i++) {
         if (!pwallet->IsSpent(hashTx, i)) {
             const CTxOut &txout = vout[i];
-            nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
+            bool isPrivate = txout.scriptPubKey.IsZerocoinMint() || txout.scriptPubKey.IsZerocoinMintV3();
+            nCredit += isPrivate ? 0 : pwallet->GetCredit(txout, ISMINE_SPENDABLE);
             if (!MoneyRange(nCredit))
                 throw std::runtime_error("CWalletTx::GetAvailableCredit() : value out of range");
         }


### PR DESCRIPTION
fix https://trello.com/c/Erv03BL2/443-fix-cwalletgetbalance-to-return-non-mints-balance and https://trello.com/c/xeHilOpH/453-insufficient-fund-to-mint-from-gui-even-there-is-enough-balance