### PR TITLE
Fix unspent mints status

### DIFF
--- a/src/zerocoin.cpp
+++ b/src/zerocoin.cpp
@@ -604,9 +604,8 @@ void DisconnectTipZC(CBlock & /*block*/, CBlockIndex *pindexDelete) {
 }
 
 CBigNum ZerocoinGetSpendSerialNumber(const CTransaction &tx, const CTxIn &txin) {
-    if (!tx.IsZerocoinSpend())
+    if (!txin.IsZerocoinSpend())
         return CBigNum(0);
-
     try {
         CDataStream serializedCoinSpend((const char *)&*(txin.scriptSig.begin() + 4),
                                     (const char *)&*txin.scriptSig.end(),


### PR DESCRIPTION
This restores mints status to unspent after zapwallettxes removed the unconfirmed spends. The spend serial information is given by the blockchain.