### PR TITLE
Pay reward back to miners when don't have znode

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -529,8 +529,10 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(
         if (nHeight >= chainparams.GetConsensus().nZnodePaymentsStartBlock) {
             const Consensus::Params &params = chainparams.GetConsensus();
             CAmount znodePayment = GetZnodePayment(chainparams.GetConsensus(), nHeight > 0 && nBlockTime >= params.nMTPSwitchTime);
-            coinbaseTx.vout[0].nValue -= znodePayment;
-            FillBlockPayments(coinbaseTx, nHeight, znodePayment, pblock->txoutZnode, pblock->voutSuperblock);
+            if(mnodeman.CountEnabled() > 0){
+                coinbaseTx.vout[0].nValue -= znodePayment;
+                FillBlockPayments(coinbaseTx, nHeight, znodePayment, pblock->txoutZnode, pblock->voutSuperblock);
+            }
         }
 
         nLastBlockTx = nBlockTx;


### PR DESCRIPTION
Reward should belong to the miner who are creating a block during network have zero znodes enabled