### PR TITLE
Allow sigma network to do Znode

### DIFF
--- a/src/znode-payments.h
+++ b/src/znode-payments.h
@@ -24,7 +24,7 @@ static const int MNPAYMENTS_SIGNATURES_TOTAL            = 10;
 // V1 - Last protocol version before update
 // V2 - Newest protocol version
 static const int MIN_ZNODE_PAYMENT_PROTO_VERSION_1 = 90024;
-static const int MIN_ZNODE_PAYMENT_PROTO_VERSION_2 = 90026;
+static const int MIN_ZNODE_PAYMENT_PROTO_VERSION_2 = 90027;
 
 extern CCriticalSection cs_vecPayees;
 extern CCriticalSection cs_mapZnodeBlocks;


### PR DESCRIPTION
In activeznode.cpp, there is following condition that does not allow znode to enable

```
if (infoMn.nProtocolVersion < MIN_ZNODE_PAYMENT_PROTO_VERSION_1
                || infoMn.nProtocolVersion > MIN_ZNODE_PAYMENT_PROTO_VERSION_2) 
```

so changing value in MIN_ZNODE_PAYMENT_PROTO_VERSION_2 to match with Protocol Verison