### PR TITLE
Fix sigma qt

### DIFF
--- a/src/qt/sigmapage.cpp
+++ b/src/qt/sigmapage.cpp
@@ -58,6 +58,8 @@ SigmaPage::SigmaPage(const PlatformStyle *platformStyle, QWidget *parent) :
     // spend
     connect(ui->addButton, SIGNAL(clicked()), this, SLOT(addEntry()));
     connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
+
+    ui->amountToMint->setLocale(QLocale::c());
 }
 
 void SigmaPage::setClientModel(ClientModel *model)


### PR DESCRIPTION
-Fix mint amount in sigma tab from `xxxx,x` to `xxxx.x`.
-Fix invalid show mint to show as |time| mint | anonymized | amount mints + fee |.

https://trello.com/c/wZzroCxF/427-decimal-point-in-sigma-dialogue
https://trello.com/c/DIlLcsY4/380-fix-transaction-list-for-multiple-mints