### PR TITLE
Add missing Sigma check

### DIFF
--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -64,6 +64,7 @@ isminetype IsMine(const CKeyStore &keystore, const CScript& scriptPubKey, bool& 
     case TX_NULL_DATA:
         break;
     case TX_ZEROCOINMINT:
+    case TX_ZEROCOINMINTV3:
     case TX_PUBKEY:
         keyID = CPubKey(vSolutions[0]).GetID();
         if (sigversion != SIGVERSION_BASE && vSolutions[0].size() != 33) {


### PR DESCRIPTION
Adds missing check for `TX_ZEROCOINMINTV3` in `ismine.cpp`.
Fixes warning:
```
script/ismine.cpp:61:13: warning: enumeration
      value 'TX_ZEROCOINMINTV3' not handled in
      switch [-Wswitch]
    switch (whichType)
            ^
script/ismine.cpp:61:13: note: add missing switch
      cases
    switch (whichType)
```