### PR TITLE
Add spend limit and enforce in consensus level.

### DIFF
--- a/qa/rpc-tests/sigma_spend_validation.py
+++ b/qa/rpc-tests/sigma_spend_validation.py
@@ -7,7 +7,8 @@ from test_framework.util import *
 # TODO fix to proper rpc_msgs after special card will be fixed.
 validation_inputs_with_funds = [
     ('valid_denom_101', 101),
-    ('valid_denom_1000', 1000),
+    ('valid_denom_400', 400),
+    ('valid_denom_1000_exceed_limit', 1000),
     ('valid_denom_1', 1),
     ('valid_denom_1.0', 1.0),
     ('ivalid_input_string', 'string'),
@@ -21,6 +22,7 @@ validation_inputs_with_funds = [
 post_outputs_with_funds = [
     (None, None),
     (None, None),
+    (-4, 'Required amount exceed value spend limit'),
     (None, None),
     (None, None),
     (-3, 'Invalid amount'),

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -255,7 +255,8 @@ class CMainParams : public CChainParams {
         consensus.nZerocoinV2MintGracefulPeriod = ZC_V2_MINT_GRACEFUL_PERIOD;
         consensus.nZerocoinV2SpendMempoolGracefulPeriod = ZC_V2_SPEND_GRACEFUL_MEMPOOL_PERIOD;
         consensus.nZerocoinV2SpendGracefulPeriod = ZC_V2_SPEND_GRACEFUL_PERIOD;
-        consensus.nMaxSigmaSpendPerBlock = 5;
+        consensus.nMaxAmountSigmaSpendPerBlock = ZC_SIGMA_AMOUNT_SPEND_LIMIT;
+        consensus.nMaxValueSigmaSpendPerBlock = ZC_SIGMA_VALUE_SPEND_LIMIT;
     }
 };
 
@@ -429,7 +430,8 @@ class CTestNetParams : public CChainParams {
             consensus.nZerocoinV2MintGracefulPeriod = ZC_V2_MINT_TESTNET_GRACEFUL_PERIOD;
             consensus.nZerocoinV2SpendMempoolGracefulPeriod = ZC_V2_SPEND_TESTNET_GRACEFUL_MEMPOOL_PERIOD;
             consensus.nZerocoinV2SpendGracefulPeriod = ZC_V2_SPEND_TESTNET_GRACEFUL_PERIOD;
-            consensus.nMaxSigmaSpendPerBlock = 30;
+            consensus.nMaxAmountSigmaSpendPerBlock = ZC_SIGMA_AMOUNT_SPEND_LIMIT;
+            consensus.nMaxValueSigmaSpendPerBlock = ZC_SIGMA_VALUE_SPEND_LIMIT;
         }
 };
 
@@ -569,7 +571,8 @@ class CRegTestParams : public CChainParams {
             consensus.nZerocoinV2MintGracefulPeriod = 5;
             consensus.nZerocoinV2SpendMempoolGracefulPeriod = 10;
             consensus.nZerocoinV2SpendGracefulPeriod = 20;
-            consensus.nMaxSigmaSpendPerBlock = 5;
+            consensus.nMaxAmountSigmaSpendPerBlock = ZC_SIGMA_AMOUNT_SPEND_LIMIT;
+            consensus.nMaxValueSigmaSpendPerBlock = ZC_SIGMA_VALUE_SPEND_LIMIT;
         }
 
         void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout) {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -255,7 +255,7 @@ class CMainParams : public CChainParams {
         consensus.nZerocoinV2MintGracefulPeriod = ZC_V2_MINT_GRACEFUL_PERIOD;
         consensus.nZerocoinV2SpendMempoolGracefulPeriod = ZC_V2_SPEND_GRACEFUL_MEMPOOL_PERIOD;
         consensus.nZerocoinV2SpendGracefulPeriod = ZC_V2_SPEND_GRACEFUL_PERIOD;
-        consensus.nMaxAmountSigmaSpendPerBlock = ZC_SIGMA_AMOUNT_SPEND_LIMIT;
+        consensus.nMaxSigmaInputPerBlock = ZC_SIGMA_INPUT_LIMIT;
         consensus.nMaxValueSigmaSpendPerBlock = ZC_SIGMA_VALUE_SPEND_LIMIT;
     }
 };
@@ -430,7 +430,7 @@ class CTestNetParams : public CChainParams {
             consensus.nZerocoinV2MintGracefulPeriod = ZC_V2_MINT_TESTNET_GRACEFUL_PERIOD;
             consensus.nZerocoinV2SpendMempoolGracefulPeriod = ZC_V2_SPEND_TESTNET_GRACEFUL_MEMPOOL_PERIOD;
             consensus.nZerocoinV2SpendGracefulPeriod = ZC_V2_SPEND_TESTNET_GRACEFUL_PERIOD;
-            consensus.nMaxAmountSigmaSpendPerBlock = ZC_SIGMA_AMOUNT_SPEND_LIMIT;
+            consensus.nMaxSigmaInputPerBlock = ZC_SIGMA_INPUT_LIMIT;
             consensus.nMaxValueSigmaSpendPerBlock = ZC_SIGMA_VALUE_SPEND_LIMIT;
         }
 };
@@ -571,7 +571,7 @@ class CRegTestParams : public CChainParams {
             consensus.nZerocoinV2MintGracefulPeriod = 5;
             consensus.nZerocoinV2SpendMempoolGracefulPeriod = 10;
             consensus.nZerocoinV2SpendGracefulPeriod = 20;
-            consensus.nMaxAmountSigmaSpendPerBlock = ZC_SIGMA_AMOUNT_SPEND_LIMIT;
+            consensus.nMaxSigmaInputPerBlock = ZC_SIGMA_INPUT_LIMIT;
             consensus.nMaxValueSigmaSpendPerBlock = ZC_SIGMA_VALUE_SPEND_LIMIT;
         }
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -124,7 +124,7 @@ struct Params {
     int nZerocoinV2SpendGracefulPeriod;
 
     // Amount of maximum sigma spend per block.
-    unsigned nMaxAmountSigmaSpendPerBlock;
+    unsigned nMaxSigmaInputPerBlock;
 
     // Value of maximum sigma spend per block.
     int64_t nMaxValueSigmaSpendPerBlock;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -123,8 +123,11 @@ struct Params {
     // Number of blocks after nSigmaMintStartBlock during which we still accept zerocoin V2 spend to newly mined blocks.
     int nZerocoinV2SpendGracefulPeriod;
 
-    // Number of maximum sigma spend per transaction.
-    unsigned nMaxSigmaSpendPerBlock;
+    // Amount of maximum sigma spend per block.
+    unsigned nMaxAmountSigmaSpendPerBlock;
+
+    // Value of maximum sigma spend per block.
+    int64_t nMaxValueSigmaSpendPerBlock;
 
     /** switch to MTP time */
     uint32_t nMTPSwitchTime;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4361,6 +4361,10 @@ bool CheckBlock(const CBlock &block, CValidationState &state,
 
         if (fCheckPOW && fCheckMerkleRoot)
             block.fChecked = true;
+
+        if (!CheckSigmaBlock(state, block)) {
+            return false;
+        }
         return true;
     } catch (const std::exception &e) {
         PrintExceptionContinue(&e, "CheckBlock() 1\n");

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -35,6 +35,7 @@
 #include "znode-sync.h"
 #include "znodeman.h"
 #include "zerocoin.h"
+#include "zerocoin_v3.h"
 #include <algorithm>
 #include <boost/thread.hpp>
 #include <boost/tuple/tuple.hpp>
@@ -321,6 +322,7 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(
         CTxMemPool::indexed_transaction_set::nth_index<3>::type::iterator mi = mempool.mapTx.get<3>().begin();
         CTxMemPool::txiter iter;
         std::size_t nSigmaSpend = 0;
+        CAmount nValueSigmaSpend(0);
 
         while (mi != mempool.mapTx.get<3>().end() || !clearedTxs.empty())
         {
@@ -415,7 +417,10 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(
                 LogPrintf("try to include zerocoinspend tx=%s\n", tx.GetHash().ToString());
 
                 if (tx.IsZerocoinSpendV3()) {
-                    if (tx.vin.size() + nSigmaSpend > params.nMaxSigmaSpendPerBlock) {
+                    if (tx.vin.size() + nSigmaSpend > params.nMaxAmountSigmaSpendPerBlock) {
+                        continue;
+                    }
+                    if (GetSpendAmount(tx) + nValueSigmaSpend > params.nMaxValueSigmaSpendPerBlock) {
                         continue;
                     }
                 } else {
@@ -466,6 +471,7 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(
                 COUNT_SPEND_ZC_TX += tx.vin.size();
                 if (tx.IsZerocoinSpendV3()) {
                     nSigmaSpend += tx.vin.size();
+                    nValueSigmaSpend += GetSpendAmount(tx);
                 }
                 inBlock.insert(iter);
                 continue;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -417,7 +417,7 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(
                 LogPrintf("try to include zerocoinspend tx=%s\n", tx.GetHash().ToString());
 
                 if (tx.IsZerocoinSpendV3()) {
-                    if (tx.vin.size() + nSigmaSpend > params.nMaxAmountSigmaSpendPerBlock) {
+                    if (tx.vin.size() + nSigmaSpend > params.nMaxSigmaInputPerBlock) {
                         continue;
                     }
                     if (GetSpendAmount(tx) + nValueSigmaSpend > params.nMaxValueSigmaSpendPerBlock) {

--- a/src/test/sigma_mintspend_numinputs.cpp
+++ b/src/test/sigma_mintspend_numinputs.cpp
@@ -49,16 +49,16 @@ BOOST_AUTO_TEST_CASE(sigma_mintspend_numinputs)
     printf("Testing number of inputs for denomination %s", denominations[denominationIndexA].c_str());
     denominationsForTx.clear();
 
-    for (unsigned i = 0; i < (consensus.nMaxAmountSigmaSpendPerBlock + 1) * 2; i++){
+    for (unsigned i = 0; i < (consensus.nMaxSigmaInputPerBlock + 1) * 2; i++){
         denominationsForTx.push_back(denominations[denominationIndexA]);
         BOOST_CHECK_MESSAGE(pwalletMain->CreateZerocoinMintModel(stringError, denominations[denominationIndexA].c_str(), SIGMA), stringError + " - Create Mint failed");
         BOOST_CHECK_MESSAGE(pwalletMain->CreateZerocoinMintModel(stringError, denominations[denominationIndexB].c_str(), SIGMA), stringError + " - Create Mint failed");
-        if (i <= consensus.nMaxAmountSigmaSpendPerBlock) {
+        if (i <= consensus.nMaxSigmaInputPerBlock) {
             denominationsForTx.push_back(denominations[denominationIndexA]);
         }
     }
 
-    BOOST_CHECK_MESSAGE(mempool.size() == (consensus.nMaxAmountSigmaSpendPerBlock + 1) * 4, "Num input mints not added to mempool");
+    BOOST_CHECK_MESSAGE(mempool.size() == (consensus.nMaxSigmaInputPerBlock + 1) * 4, "Num input mints not added to mempool");
 
     // add block
     previousHeight = chainActive.Height();
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(sigma_mintspend_numinputs)
     // Check that the tx creation fails.
     BOOST_CHECK_MESSAGE(!pwalletMain->CreateZerocoinSpendModel(wtx, stringError, thirdPartyAddress, denominationsForTx), "Spend succeeded even though number of inputs exceed the limits");
 
-    unsigned spendsTransactionLimit = consensus.nMaxAmountSigmaSpendPerBlock / 2;
+    unsigned spendsTransactionLimit = consensus.nMaxSigmaInputPerBlock / 2;
     // Next add spendsTransactionLimit + 1 transactions with 2 inputs each, verify mempool==spendsTransactionLimit + 1. mine a block. Verify mempool still has 1 tx.
     for(unsigned i = 0; i < spendsTransactionLimit + 1; i++){
         denominationsForTx.clear();
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(spend_value_limit)
     const CBitcoinAddress randomAddr1(newKey1.GetID());
     const CBitcoinAddress randomAddr2(newKey2.GetID());
 
-    string stringError;
+    std::string stringError;
     auto& consensus = Params().GetConsensus();
 
     auto testDenomination = sigma::CoinDenominationV3::SIGMA_DENOM_100;

--- a/src/test/sigma_mintspend_numinputs.cpp
+++ b/src/test/sigma_mintspend_numinputs.cpp
@@ -64,6 +64,7 @@ BOOST_AUTO_TEST_CASE(sigma_mintspend_numinputs)
     previousHeight = chainActive.Height();
     b = CreateAndProcessBlock({}, scriptPubKey);
     wtx.Init(NULL);
+
     //Add 5 more blocks
     for (int i = 0; i < 5; i++)
     {
@@ -77,25 +78,111 @@ BOOST_AUTO_TEST_CASE(sigma_mintspend_numinputs)
     // Check that the tx creation fails.
     BOOST_CHECK_MESSAGE(!pwalletMain->CreateZerocoinSpendModel(wtx, stringError, thirdPartyAddress, denominationsForTx), "Spend succeeded even though number of inputs exceed the limits");
 
-    // Next add 3 transactions with 2 inputs each, verify mempool==3. mine a block. Verify mempool still has 1 tx.
-    for(int i=0;i<3;i++){
+    unsigned spendsTransactionLimit = consensus.nMaxAmountSigmaSpendPerBlock / 2;
+    // Next add spendsTransactionLimit + 1 transactions with 2 inputs each, verify mempool==spendsTransactionLimit + 1. mine a block. Verify mempool still has 1 tx.
+    for(unsigned i = 0; i < spendsTransactionLimit + 1; i++){
         denominationsForTx.clear();
         denominationsForTx.push_back(denominations[denominationIndexA]);
         denominationsForTx.push_back(denominations[denominationIndexB]);
         BOOST_CHECK_MESSAGE(pwalletMain->CreateZerocoinSpendModel(wtx, stringError, thirdPartyAddress, denominationsForTx), "Spend Failed");
     }
 
-    BOOST_CHECK_MESSAGE(mempool.size() == 3, "Num input spends not added to mempool");
+    BOOST_CHECK_MESSAGE(mempool.size() == spendsTransactionLimit + 1, "Num input spends not added to mempool");
 
     // add block
     b = CreateAndProcessBlock({}, scriptPubKey);
     wtx.Init(NULL);
 
-    BOOST_CHECK_MESSAGE(mempool.size() != 3 && mempool.size() == 1 && mempool.size() != 0, "Mempool not correctly cleared: Block spend limit not enforced.");
+    BOOST_CHECK_MESSAGE(mempool.size() == 1, "Mempool not correctly cleared: Block spend limit not enforced.");
 
     vtxid.clear();
     mempool.clear();
     zerocoinState->Reset();
 }
+
+BOOST_AUTO_TEST_CASE(spend_value_limit)
+{
+    // Generate addresses
+    CPubKey newKey1, newKey2;
+    BOOST_CHECK_MESSAGE(pwalletMain->GetKeyFromPool(newKey1), "Fail to get new address");
+    BOOST_CHECK_MESSAGE(pwalletMain->GetKeyFromPool(newKey2), "Fail to get new address");
+
+    const CBitcoinAddress randomAddr1(newKey1.GetID());
+    const CBitcoinAddress randomAddr2(newKey2.GetID());
+
+    string stringError;
+    auto& consensus = Params().GetConsensus();
+
+    auto testDenomination = sigma::CoinDenominationV3::SIGMA_DENOM_100;
+    std::string testDenominationStr = std::to_string(testDenomination);
+    CAmount testDenominationAmount;
+    sigma::DenominationToInteger(testDenomination, testDenominationAmount);
+
+    // Create 400-200+1 = 201 new empty blocks. // consensus.nMintV3SigmaStartBlock = 400
+    CreateAndProcessEmptyBlocks(201, scriptPubKey);
+
+    pwalletMain->SetBroadcastTransactions(true);
+
+    // Mint coins to ensure have coins enough to choose more than value limit.
+    CAmount allMintsValue(0);
+    while (allMintsValue <= consensus.nMaxValueSigmaSpendPerBlock * 2){
+        BOOST_CHECK_MESSAGE(pwalletMain->CreateZerocoinMintModel(stringError, testDenominationStr, SIGMA), stringError + " - Create Mint failed");
+        allMintsValue += testDenominationAmount;
+    }
+
+    // Ensure all mint coins be able to use.
+    BOOST_CHECK_NE(mempool.size(), 0);
+    CreateAndProcessBlock({}, scriptPubKey);
+    BOOST_CHECK_EQUAL(mempool.size(), 0);
+    CreateAndProcessEmptyBlocks(5, scriptPubKey);
+
+    // Try to spend at value limit with single vout.
+    std::vector<CRecipient> recipients = {
+        {GetScriptForDestination(randomAddr1.Get()), testDenominationAmount * 5, false},
+    };
+
+    CWalletTx tx;
+
+    // This should fail because we need to use spends more than limit.
+    BOOST_CHECK_EXCEPTION(
+        pwalletMain->SpendZerocoinV3(recipients, tx),
+        std::runtime_error,
+        [](const std::runtime_error& e){return e.what() == std::string("Required amount exceed value spend limit");});
+
+    // Try to spend at value limit with two vout.
+    recipients = {
+        {GetScriptForDestination(randomAddr1.Get()), testDenominationAmount * 4, false},
+        {GetScriptForDestination(randomAddr2.Get()), testDenominationAmount * 1, false},
+    };
+    // This should fail because we need to use spends more than limit.
+    BOOST_CHECK_EXCEPTION(
+        pwalletMain->SpendZerocoinV3(recipients, tx),
+        std::runtime_error,
+        [](const std::runtime_error& e){return e.what() == std::string("Required amount exceed value spend limit");});
+
+    // Try to spend two transactions which each transaction not over limit.
+    // But sum of spend in both transaction exceed limit.
+    // Then both transactions should be included to mempool but never be mined together.
+    recipients = {
+        {GetScriptForDestination(randomAddr1.Get()), testDenominationAmount * 2, false},
+        {GetScriptForDestination(randomAddr2.Get()), testDenominationAmount * 1, false},
+    };
+
+    BOOST_CHECK_NO_THROW(pwalletMain->SpendZerocoinV3(recipients, tx));
+    BOOST_CHECK_EQUAL(mempool.size(), 1);
+
+    recipients = {
+        {GetScriptForDestination(randomAddr1.Get()), testDenominationAmount * 3, false},
+    };
+
+    BOOST_CHECK_NO_THROW(pwalletMain->SpendZerocoinV3(recipients, tx));
+    BOOST_CHECK_EQUAL(mempool.size(), 2);
+
+    CreateAndProcessBlock({}, scriptPubKey);
+    BOOST_CHECK_EQUAL(mempool.size(), 1);
+
+    mempool.clear();
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/src/test/sigma_mintspend_numinputs.cpp
+++ b/src/test/sigma_mintspend_numinputs.cpp
@@ -49,16 +49,16 @@ BOOST_AUTO_TEST_CASE(sigma_mintspend_numinputs)
     printf("Testing number of inputs for denomination %s", denominations[denominationIndexA].c_str());
     denominationsForTx.clear();
 
-    for (unsigned i = 0; i < (consensus.nMaxSigmaSpendPerBlock+1)*2; i++){
+    for (unsigned i = 0; i < (consensus.nMaxAmountSigmaSpendPerBlock + 1) * 2; i++){
         denominationsForTx.push_back(denominations[denominationIndexA]);
         BOOST_CHECK_MESSAGE(pwalletMain->CreateZerocoinMintModel(stringError, denominations[denominationIndexA].c_str(), SIGMA), stringError + " - Create Mint failed");
         BOOST_CHECK_MESSAGE(pwalletMain->CreateZerocoinMintModel(stringError, denominations[denominationIndexB].c_str(), SIGMA), stringError + " - Create Mint failed");
-        if (i <= consensus.nMaxSigmaSpendPerBlock) {
+        if (i <= consensus.nMaxAmountSigmaSpendPerBlock) {
             denominationsForTx.push_back(denominations[denominationIndexA]);
         }
     }
 
-    BOOST_CHECK_MESSAGE(mempool.size() == (consensus.nMaxSigmaSpendPerBlock+1)*4, "Num input mints not added to mempool");
+    BOOST_CHECK_MESSAGE(mempool.size() == (consensus.nMaxAmountSigmaSpendPerBlock + 1) * 4, "Num input mints not added to mempool");
 
     // add block
     previousHeight = chainActive.Height();

--- a/src/test/sigma_mintspend_numinputs.cpp
+++ b/src/test/sigma_mintspend_numinputs.cpp
@@ -146,8 +146,8 @@ BOOST_AUTO_TEST_CASE(spend_value_limit)
     // This should fail because we need to use spends more than limit.
     BOOST_CHECK_EXCEPTION(
         pwalletMain->SpendZerocoinV3(recipients, tx),
-        std::runtime_error,
-        [](const std::runtime_error& e){return e.what() == std::string("Required amount exceed value spend limit");});
+        std::invalid_argument,
+        [](const std::invalid_argument& e){return e.what() == std::string("Required amount exceed value spend limit");});
 
     // Try to spend at value limit with two vout.
     recipients = {
@@ -157,8 +157,8 @@ BOOST_AUTO_TEST_CASE(spend_value_limit)
     // This should fail because we need to use spends more than limit.
     BOOST_CHECK_EXCEPTION(
         pwalletMain->SpendZerocoinV3(recipients, tx),
-        std::runtime_error,
-        [](const std::runtime_error& e){return e.what() == std::string("Required amount exceed value spend limit");});
+        std::invalid_argument,
+        [](const std::invalid_argument& e){return e.what() == std::string("Required amount exceed value spend limit");});
 
     // Try to spend two transactions which each transaction not over limit.
     // But sum of spend in both transaction exceed limit.

--- a/src/wallet/sigmaspendbuilder.cpp
+++ b/src/wallet/sigmaspendbuilder.cpp
@@ -127,7 +127,8 @@ CAmount SigmaSpendBuilder::GetInputs(std::vector<std::unique_ptr<InputSigner>>& 
     selected.clear();
     denomChanges.clear();
 
-    if (!wallet.GetCoinsToSpend(required, selected, denomChanges, Params().GetConsensus().nMaxSigmaInputPerBlock)) {
+    if (!wallet.GetCoinsToSpend(required, selected, denomChanges,
+        Params().GetConsensus().nMaxSigmaInputPerBlock, Params().GetConsensus().nMaxValueSigmaSpendPerBlock)) {
         throw InsufficientFunds();
     }
 

--- a/src/wallet/sigmaspendbuilder.cpp
+++ b/src/wallet/sigmaspendbuilder.cpp
@@ -127,7 +127,7 @@ CAmount SigmaSpendBuilder::GetInputs(std::vector<std::unique_ptr<InputSigner>>& 
     selected.clear();
     denomChanges.clear();
 
-    if (!wallet.GetCoinsToSpend(required, selected, denomChanges, Params().GetConsensus().nMaxAmountSigmaSpendPerBlock)) {
+    if (!wallet.GetCoinsToSpend(required, selected, denomChanges, Params().GetConsensus().nMaxSigmaInputPerBlock)) {
         throw InsufficientFunds();
     }
 

--- a/src/wallet/sigmaspendbuilder.cpp
+++ b/src/wallet/sigmaspendbuilder.cpp
@@ -127,7 +127,7 @@ CAmount SigmaSpendBuilder::GetInputs(std::vector<std::unique_ptr<InputSigner>>& 
     selected.clear();
     denomChanges.clear();
 
-    if (!wallet.GetCoinsToSpend(required, selected, denomChanges)) {
+    if (!wallet.GetCoinsToSpend(required, selected, denomChanges, Params().GetConsensus().nMaxAmountSigmaSpendPerBlock)) {
         throw InsufficientFunds();
     }
 

--- a/src/wallet/test/sigma_tests.cpp
+++ b/src/wallet/test/sigma_tests.cpp
@@ -290,8 +290,6 @@ BOOST_AUTO_TEST_CASE(get_coin_not_enough)
     std::vector<CZerocoinEntryV3> coins;
     std::vector<sigma::CoinDenominationV3> coinsToMint;
     BOOST_CHECK_THROW(pwalletMain->GetCoinsToSpend(require, coins, coinsToMint), InsufficientFunds);
-    // BOOST_CHECK_MESSAGE(!pwalletMain->GetCoinsToSpend(require, coins, coinsToMint),
-    //     "Expect not enough coin and equal to one for each denomination");
 }
 
 BOOST_AUTO_TEST_CASE(get_coin_cannot_spend_unconfirmed_coins)
@@ -386,8 +384,7 @@ BOOST_AUTO_TEST_CASE(get_coin_by_limit_max_to_1)
     std::vector<sigma::CoinDenominationV3> coinsToMint;
     BOOST_CHECK_EXCEPTION(pwalletMain->GetCoinsToSpend(require, coins, coinsToMint, 1),
         std::runtime_error,
-        [](const std::runtime_error& e){
-            std::cout << e.what() << std::endl;
+        [](const std::runtime_error& e) {
             return e.what() == std::string("Can not choose coins within limit.");
         });
 }

--- a/src/wallet/txbuilder.cpp
+++ b/src/wallet/txbuilder.cpp
@@ -118,11 +118,6 @@ CWalletTx TxBuilder::Build(const std::vector<CRecipient>& recipients, CAmount& f
             required += fee;
         }
 
-        if (required > Params().GetConsensus().nMaxValueSigmaSpendPerBlock) {
-            throw std::runtime_error(
-                _("Required amount exceed value spend limit"));
-        }
-
         // fill outputs
         bool remainderSubtracted = false;
 

--- a/src/wallet/txbuilder.cpp
+++ b/src/wallet/txbuilder.cpp
@@ -118,6 +118,11 @@ CWalletTx TxBuilder::Build(const std::vector<CRecipient>& recipients, CAmount& f
             required += fee;
         }
 
+        if (required > Params().GetConsensus().nMaxValueSigmaSpendPerBlock) {
+            throw std::runtime_error(
+                _("Required amount exceed value spend limit"));
+        }
+
         // fill outputs
         bool remainderSubtracted = false;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5129,6 +5129,11 @@ CWalletTx CWallet::CreateZerocoinSpendTransactionV3(
     selected = builder.selected;
     changes = builder.changes;
 
+    if (GetSpendAmount(tx) > Params().GetConsensus().nMaxValueSigmaSpendPerBlock) {
+        throw std::runtime_error(
+            _("Required amount exceed value spend limit"));
+    };
+
     return tx;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2254,7 +2254,13 @@ bool CWallet::GetCoinsToSpend(
         throw InsufficientFunds();
     }
 
-    int limitVal = amountLimit/zeros;
+    int limitVal;
+    if (amountLimit > MAX_MONEY) {
+        limitVal = MAX_MONEY / zeros;
+    } else {
+        limitVal = amountLimit / zeros;
+    }
+
     if (required > limitVal) {
         throw std::runtime_error(
             _("Required amount exceed value spend limit"));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2254,15 +2254,15 @@ bool CWallet::GetCoinsToSpend(
         throw InsufficientFunds();
     }
 
-    int limitVal;
     if (amountLimit > MAX_MONEY) {
-        limitVal = MAX_MONEY / zeros;
-    } else {
-        limitVal = amountLimit / zeros;
+        throw std::invalid_argument(
+            _("Amount limit is exceed max money"));
     }
 
+    size_t limitVal = amountLimit / zeros;
+
     if (required > limitVal) {
-        throw std::runtime_error(
+        throw std::invalid_argument(
             _("Required amount exceed value spend limit"));
     }
 
@@ -2281,8 +2281,10 @@ bool CWallet::GetCoinsToSpend(
         throw runtime_error("Unknown sigma denomination.\n");
     }
 
+    size_t val = required + max_coin_value / zeros;
 
-    int val = required + max_coin_value / zeros;
+    // val represent max value in range that we will search which may be over limit.
+    // then we trim it out because we never use it.
     if (val > limitVal) {
         val = limitVal;
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2249,7 +2249,7 @@ bool CWallet::GetCoinsToSpend(
         availableBalance += coin.get_denomination_value();
     }
 
-    if (required > availableBalance) {
+    if (required * zeros > availableBalance) {
         throw InsufficientFunds();
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2277,8 +2277,6 @@ bool CWallet::GetCoinsToSpend(
     }
 
     std::list<CZerocoinEntryV3> coins = GetAvailableCoins();
-    if (coins.empty())
-        return false;
 
     CAmount availableBalance = CalculateCoinsBalance(coins.begin(), coins.end());
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -879,7 +879,8 @@ public:
     bool GetCoinsToSpend(
         CAmount required,
         std::vector<CZerocoinEntryV3>& coinsToSpend_out,
-        std::vector<sigma::CoinDenominationV3>& coinsToMint_out) const;
+        std::vector<sigma::CoinDenominationV3>& coinsToMint_out,
+        const size_t coinsLimit = SIZE_MAX) const;
 
     /**
      * Insert additional inputs into the transaction by

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -880,7 +880,8 @@ public:
         CAmount required,
         std::vector<CZerocoinEntryV3>& coinsToSpend_out,
         std::vector<sigma::CoinDenominationV3>& coinsToMint_out,
-        const size_t coinsLimit = SIZE_MAX) const;
+        const size_t coinsLimit = SIZE_MAX,
+        const CAmount amountLimit = MAX_MONEY) const;
 
     /**
      * Insert additional inputs into the transaction by

--- a/src/zerocoin_params.h
+++ b/src/zerocoin_params.h
@@ -95,10 +95,10 @@ static const int64_t DUST_HARD_LIMIT = 1000;   // 0.00001 XZC mininput
 #define ZC_SPEND_LIMIT         5
 
 // Value of sigma spends allowed per block
-#define ZC_SIGMA_VALUE_SPEND_LIMIT         50000000000
+#define ZC_SIGMA_VALUE_SPEND_LIMIT         (500 * COIN)
 
 // Amount of sigma spends allowed per block
-#define ZC_SIGMA_AMOUNT_SPEND_LIMIT         50
+#define ZC_SIGMA_INPUT_LIMIT         50
 
 // Number of zerocoin mints allowed per transaction
 #define ZC_MINT_LIMIT         100

--- a/src/zerocoin_params.h
+++ b/src/zerocoin_params.h
@@ -94,6 +94,12 @@ static const int64_t DUST_HARD_LIMIT = 1000;   // 0.00001 XZC mininput
 // Number of zerocoin spends allowed per block and per transaction
 #define ZC_SPEND_LIMIT         5
 
+// Value of sigma spends allowed per block
+#define ZC_SIGMA_VALUE_SPEND_LIMIT         50000000000
+
+// Amount of sigma spends allowed per block
+#define ZC_SIGMA_AMOUNT_SPEND_LIMIT         50
+
 // Number of zerocoin mints allowed per transaction
 #define ZC_MINT_LIMIT         100
 #endif

--- a/src/zerocoin_v3.h
+++ b/src/zerocoin_v3.h
@@ -46,6 +46,9 @@ bool IsSigmaAllowed(int height);
 
 secp_primitives::GroupElement ParseSigmaMintScript(const CScript& script);
 std::pair<std::unique_ptr<sigma::CoinSpendV3>, uint32_t> ParseSigmaSpend(const CTxIn& in);
+CAmount GetSpendAmount(const CTxIn& in);
+CAmount GetSpendAmount(const CTransaction& tx);
+bool CheckSigmaBlock(CValidationState &state, const CBlock& block);
 
 bool CheckZerocoinTransactionV3(
   const CTransaction &tx,


### PR DESCRIPTION
Enforce amount of spend inputs at 50 per block.
Enforce value of spends at 500 XZC per block.