### PR TITLE
Fix sigma page

### DIFF
--- a/src/qt/sigmapage.cpp
+++ b/src/qt/sigmapage.cpp
@@ -258,8 +258,7 @@ void SigmaPage::on_sendButton_clicked()
     // process sendStatus and on error generate message shown to user
     processSpendCoinsReturn(sendStatus);
 
-    if (sendStatus.status == WalletModel::OK)
-    {
+    if (sendStatus.status == WalletModel::OK) {
         accept();
     }
 

--- a/src/qt/sigmapage.cpp
+++ b/src/qt/sigmapage.cpp
@@ -258,6 +258,11 @@ void SigmaPage::on_sendButton_clicked()
     // process sendStatus and on error generate message shown to user
     processSpendCoinsReturn(sendStatus);
 
+    if (sendStatus.status == WalletModel::OK)
+    {
+        accept();
+    }
+
     isNewRecipientAllowed = true;
 }
 
@@ -270,6 +275,11 @@ void SigmaPage::clear()
     addEntry();
 
     updateTabsAndLabels();
+}
+
+void SigmaPage::accept()
+{
+    clear();
 }
 
 SendCoinsEntry *SigmaPage::addEntry() {

--- a/src/qt/sigmapage.h
+++ b/src/qt/sigmapage.h
@@ -29,6 +29,7 @@ public:
 
 public Q_SLOTS:
     void clear();
+    void accept();
     SendCoinsEntry* addEntry();
     void updateTabsAndLabels();
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -87,6 +87,9 @@ WalletView::WalletView(const PlatformStyle *platformStyle, QWidget *parent):
     // Clicking on a transaction on the overview pre-selects the transaction on the transaction history page
     connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), this, SLOT(focusBitcoinHistoryTab(QModelIndex)));
     connect(overviewPage, SIGNAL(exodusTransactionClicked(uint256)), this, SLOT(focusExodusTransaction(uint256)));
+
+    // Subscribe message from sigma tab.
+    connect(sigmaPage, SIGNAL(message(QString, QString, unsigned int)), this, SIGNAL(message(QString, QString, unsigned int)));
 }
 
 WalletView::~WalletView()


### PR DESCRIPTION
- spend entries isn't cleared after spend success
- error message isn't show when create spend transaction with duplicated addresses.