### PR TITLE
CoinControl support for sigma mints [QT]

### DIFF
--- a/src/qt/sigmapage.cpp
+++ b/src/qt/sigmapage.cpp
@@ -15,6 +15,9 @@
 #include "../wallet/walletdb.h"
 #include "../sigma/coin.h"
 
+#include <qt/coincontroldialog.h>
+#include <coincontrol.h>
+
 #include <QMessageBox>
 #include <QScrollBar>
 #include <QTextDocument>
@@ -121,6 +124,9 @@ void SigmaPage::on_mintButton_clicked()
     amount = amount / CENT * CENT + ((amount % CENT >= CENT / 2) ? CENT : 0);
 
     try {
+        if (walletModel->getOptionsModel()->getCoinControlFeatures())
+            g_coincontrol = *CoinControlDialog::coinControl;
+
         walletModel->sigmaMint(amount);
     } catch (const std::runtime_error& e) {
         QMessageBox::critical(this, tr("Error"),

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -77,6 +77,9 @@ class CScript;
 class CTxMemPool;
 class CWalletTx;
 
+// global coin support for QT mint access
+extern CCoinControl g_coincontrol;
+
 /** (client) version numbers for particular wallet features */
 enum WalletFeature
 {


### PR DESCRIPTION
Add global coin control support so you can manage the coins you are minting within QT. Carries over from the QT send screen.