### PR TITLE
Make error message more clear

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4171,7 +4171,7 @@ bool CheckBlock(const CBlock &block, CValidationState &state,
             nHeight = ZerocoinGetNHeight(block.GetBlockHeader());
 
         if (!CheckZerocoinFoundersInputs(block.vtx[0], state, Params().GetConsensus(), nHeight, block.IsMTP())) {
-            return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(), "Zerocoin founders input check failure");
+            return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(), "Founders' reward check failed");
         }
 
         BOOST_FOREACH(const CTransaction &tx, block.vtx) {


### PR DESCRIPTION
Old message seemed to refer to Zcoin as "Zerocoin" and wasn't as clear. Note that this is only part of the log message.