### PR TITLE
New denominations

### DIFF
--- a/qa/rpc-tests/sigma_mint_validation.py
+++ b/qa/rpc-tests/sigma_mint_validation.py
@@ -6,6 +6,7 @@ from test_framework.util import *
 
 validation_inputs_no_funds = [
     ('valid_denom_1', 1),
+    ('valid_denom_0.05', 0.05),
     ('valid_denom_0.1', 0.1),
     ('valid_denom_0.5', 0.5),
     ('valid_denom_5', 5),
@@ -15,6 +16,8 @@ validation_inputs_no_funds = [
     ('valid_denom_50', 50),
     ('valid_denom_101', 101),
     ('valid_denom_1.0', 1.0),
+    ('valid_denom_1.00', 1.00),
+    ('valid_denom_1.95', 1.95),
     ('ivalid_input_string', 'string'),
     ('ivalid_input_string_with_num', '1'),
     ('ivalid_input_empty', None),
@@ -22,10 +25,14 @@ validation_inputs_no_funds = [
     ('invalid_denom_out_of_100000000', 100000000),
     ('valid_denom_1000', 1000),
     ('invalid_denom_0.01', 0.01),
+    ('invalid_denom_0.07', 0.07),
     ('invalid_denom_-1', -1),
 ]
 
 post_outputs_no_funds = [
+    (None, None),
+    (None, None),
+    (None, None),
     (None, None),
     (None, None),
     (None, None),
@@ -42,6 +49,7 @@ post_outputs_no_funds = [
     (-3, 'Invalid amount'),
     (-3, 'Amount out of range'),
     (None, None),
+    (-8, 'Amount to mint is invalid.\n'),
     (-8, 'Amount to mint is invalid.\n'),
     (-3, 'Amount out of range')
 ]

--- a/src/qt/forms/sigmapage.ui
+++ b/src/qt/forms/sigmapage.ui
@@ -53,42 +53,8 @@
          <property name="leftMargin">
           <number>10</number>
          </property>
-         <item row="5" column="0" colspan="3">
-          <layout class="QFormLayout" name="formLayout_2">
-           <property name="horizontalSpacing">
-            <number>0</number>
-           </property>
-           <item row="1" column="1">
-            <widget class="Line" name="line_5">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="label_denom_01">
-           <property name="text">
-            <string>0.1</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="label_denom_1">
-           <property name="text">
-            <string>1</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QLabel" name="amountDenom1">
+         <item row="6" column="1">
+          <widget class="QLabel" name="amountDenom005">
            <property name="text">
             <string>0</string>
            </property>
@@ -97,8 +63,18 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
-          <widget class="QLabel" name="amountDenom10">
+         <item row="6" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>0.05</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="amountDenom100">
            <property name="text">
             <string>0</string>
            </property>
@@ -107,7 +83,7 @@
            </property>
           </widget>
          </item>
-         <item row="8" column="2">
+         <item row="10" column="2">
           <widget class="QLabel" name="label_19">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -129,7 +105,17 @@
            </property>
           </widget>
          </item>
-         <item row="8" column="1">
+         <item row="9" column="1">
+          <widget class="QLabel" name="spendable">
+           <property name="text">
+            <string>0.0</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="1">
           <widget class="QLabel" name="total">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -157,7 +143,87 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="1">
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_denom_10">
+           <property name="text">
+            <string>10</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="2">
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>XZC</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QLabel" name="amountDenom05">
+           <property name="text">
+            <string>0</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="QLabel" name="amountDenom01">
+           <property name="text">
+            <string>0</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_denom_1">
+           <property name="text">
+            <string>1</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLabel" name="amountDenom1">
+           <property name="text">
+            <string>0</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="label_denom_01">
+           <property name="text">
+            <string>0.1</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLabel" name="amountDenom10">
+           <property name="text">
+            <string>0</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
           <widget class="QLabel" name="pending">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -185,17 +251,38 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
-          <widget class="QLabel" name="amountDenom05">
+         <item row="7" column="0" colspan="3">
+          <layout class="QFormLayout" name="formLayout_2">
+           <property name="horizontalSpacing">
+            <number>0</number>
+           </property>
+           <item row="1" column="1">
+            <widget class="Line" name="line_5">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="8" column="0">
+          <widget class="QLabel" name="label_11">
            <property name="text">
-            <string>0</string>
+            <string>Pending:</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
+         <item row="9" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>Spendable:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
           <widget class="QLabel" name="label_denom_05">
            <property name="text">
             <string>0.5</string>
@@ -205,63 +292,7 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="1">
-          <widget class="QLabel" name="amountDenom100">
-           <property name="text">
-            <string>0</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_denom_10">
-           <property name="text">
-            <string>10</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="0">
-          <widget class="QLabel" name="label_12">
-           <property name="font">
-            <font>
-             <weight>75</weight>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Total:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_denom_100">
-           <property name="text">
-            <string>100</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="QLabel" name="amountDenom01">
-           <property name="text">
-            <string>0</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="2">
+         <item row="8" column="2">
           <widget class="QLabel" name="label_18">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -283,37 +314,46 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="label_11">
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_9">
            <property name="text">
-            <string>Pending:</string>
+            <string>25</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>
-         <item row="7" column="0">
-          <widget class="QLabel" name="label_6">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_denom_100">
            <property name="text">
-            <string>Spendable:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="2">
-          <widget class="QLabel" name="label_7">
-           <property name="text">
-            <string>XZC</string>
+            <string>100</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignCenter</set>
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>
-         <item row="7" column="1">
-          <widget class="QLabel" name="spendable">
+         <item row="10" column="0">
+          <widget class="QLabel" name="label_12">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
            <property name="text">
-            <string>0.0</string>
+            <string>Total:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="amountDenom25">
+           <property name="text">
+            <string>0</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -352,7 +392,7 @@
       <string notr="true"/>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabMint">
       <attribute name="title">
@@ -382,13 +422,13 @@
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
              <property name="decimals">
-              <number>1</number>
+              <number>2</number>
              </property>
              <property name="maximum">
               <double>21000000.000000000000000</double>
              </property>
              <property name="singleStep">
-              <double>0.100000000000000</double>
+              <double>0.050000000000000</double>
              </property>
             </widget>
            </item>
@@ -601,8 +641,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>697</width>
-                <height>189</height>
+                <width>685</width>
+                <height>169</height>
                </rect>
               </property>
               <property name="autoFillBackground">

--- a/src/qt/sigmapage.cpp
+++ b/src/qt/sigmapage.cpp
@@ -111,14 +111,43 @@ void SigmaPage::numBlocksChanged(int count, const QDateTime& blockDate, double n
     }
 }
 
+static QString formatAmount(CAmount n);
+
 void SigmaPage::on_mintButton_clicked()
 {
     auto rawAmount = ui->amountToMint->value();
     CAmount amount(rawAmount * COIN);
 
-    // round any thing smaller than 0.1
-    // if more than or equal 0.05 round to 0.1 otherwise round to 0.0
+    // round any thing smaller than 0.01
+    // if more than or equal 0.005 round to 0.01 otherwise round to 0.00
     amount = amount / CENT * CENT + ((amount % CENT >= CENT / 2) ? CENT : 0);
+
+    // check if amount to mint is impossible to process.
+    std::vector<sigma::CoinDenomination> denoms;
+    sigma::GetAllDenoms(denoms);
+
+    auto smallestDenomination = denoms.back();
+    CAmount smallestDenominationValue;
+    sigma::DenominationToInteger(smallestDenomination, smallestDenominationValue);
+
+    if (amount < smallestDenominationValue) {
+        QMessageBox::critical(this, tr("Too small amount to mint"),
+            tr("Amount to mint must not lower than %1 XZC.").arg(formatAmount(smallestDenominationValue)),
+            QMessageBox::Ok, QMessageBox::Ok);
+        return;
+    }
+
+    if (amount % smallestDenominationValue != 0) {
+        amount -= amount % smallestDenominationValue;
+        auto reply = QMessageBox::question(
+            this, tr("Amount to mint is impossible."),
+            tr("Amount to mint must be multiple of 0.05 XZC. Do you want to spend %1 XZC?"
+            ).arg(formatAmount(amount)));
+
+        if (reply == QMessageBox::No) {
+            return;
+        }
+    }
 
     try {
         WalletModel::UnlockContext ctx(walletModel->requestUnlock());
@@ -401,10 +430,10 @@ static QString formatAmount(CAmount n)
 
     qint64 n_abs = (n > 0 ? n : -n);
     qint64 quotient = n_abs / coin;
-    qint64 remainder = (n_abs % coin) * 10 / coin;
+    qint64 remainder = (n_abs % coin) * 100 / coin;
 
     QString quotient_str = QString::number(quotient);
-    QString remainder_str = QString::number(remainder).rightJustified(1, '0');
+    QString remainder_str = QString::number(remainder).rightJustified(2, '0');
 
     if (n < 0)
         quotient_str.insert(0, '-');
@@ -423,16 +452,20 @@ void SigmaPage::updateCoins(const std::vector<CSigmaEntry>& spendable, const std
 
     // update coins amount
     int denom100Amount = spendableDenominationCoins[sigma::CoinDenomination::SIGMA_DENOM_100];
+    int denom25Amount = spendableDenominationCoins[sigma::CoinDenomination::SIGMA_DENOM_25];
     int denom10Amount = spendableDenominationCoins[sigma::CoinDenomination::SIGMA_DENOM_10];
     int denom1Amount = spendableDenominationCoins[sigma::CoinDenomination::SIGMA_DENOM_1];
     int denom05Amount = spendableDenominationCoins[sigma::CoinDenomination::SIGMA_DENOM_0_5];
     int denom01Amount = spendableDenominationCoins[sigma::CoinDenomination::SIGMA_DENOM_0_1];
+    int denom005Amount = spendableDenominationCoins[sigma::CoinDenomination::SIGMA_DENOM_0_05];
 
     ui->amountDenom100->setText(QString::fromStdString(std::to_string(denom100Amount)));
+    ui->amountDenom25->setText(QString::fromStdString(std::to_string(denom25Amount)));
     ui->amountDenom10->setText(QString::fromStdString(std::to_string(denom10Amount)));
     ui->amountDenom1->setText(QString::fromStdString(std::to_string(denom1Amount)));
     ui->amountDenom05->setText(QString::fromStdString(std::to_string(denom05Amount)));
     ui->amountDenom01->setText(QString::fromStdString(std::to_string(denom01Amount)));
+    ui->amountDenom005->setText(QString::fromStdString(std::to_string(denom005Amount)));
 
     CAmount pendingSum(0);
     for (const auto& c : pending) {

--- a/src/sigma/coin.cpp
+++ b/src/sigma/coin.cpp
@@ -26,17 +26,23 @@ bool DenominationToInteger(CoinDenomination denom, int64_t& denom_out, CValidati
     switch (denom) {
         default:
             return state.DoS(100, error("CheckZerocoinTransaction : invalid denomination value, unable to convert to integer"));
+        case CoinDenomination::SIGMA_DENOM_0_05:
+            denom_out = 5 * CENT;
+            break;
         case CoinDenomination::SIGMA_DENOM_0_1:
-            denom_out = COIN / 10;
+            denom_out = 10 * CENT;
             break;
         case CoinDenomination::SIGMA_DENOM_0_5:
-            denom_out = COIN / 2;
+            denom_out = 50 * CENT;
             break;
         case CoinDenomination::SIGMA_DENOM_1:
             denom_out = COIN;
             break;
         case CoinDenomination::SIGMA_DENOM_10:
             denom_out = 10 * COIN;
+            break;
+        case CoinDenomination::SIGMA_DENOM_25:
+            denom_out = 25 * COIN;
             break;
         case CoinDenomination::SIGMA_DENOM_100:
             denom_out = 100 * COIN;
@@ -50,6 +56,10 @@ bool RealNumberToDenomination(const double& value, CoinDenomination& denom_out) 
 }
 
 bool StringToDenomination(const std::string& str, CoinDenomination& denom_out) {
+    if (str == "0.05") {
+        denom_out = CoinDenomination::SIGMA_DENOM_0_05;
+        return true;
+    }
     if (str == "0.1") {
         denom_out = CoinDenomination::SIGMA_DENOM_0_1;
         return true;
@@ -64,6 +74,10 @@ bool StringToDenomination(const std::string& str, CoinDenomination& denom_out) {
     }
     if (str == "10") {
         denom_out = CoinDenomination::SIGMA_DENOM_10;
+        return true;
+    }
+    if (str == "25") {
+        denom_out = CoinDenomination::SIGMA_DENOM_25;
         return true;
     }
     if (str == "100") {
@@ -82,10 +96,13 @@ bool IntegerToDenomination(int64_t value, CoinDenomination& denom_out, CValidati
     switch (value) {
         default:
             return state.DoS(100, error("CheckZerocoinTransaction : invalid denomination value, unable to convert to enum"));
-        case COIN / 10:
+        case 5 * CENT:
+            denom_out = CoinDenomination::SIGMA_DENOM_0_05;
+            break;
+        case 10 * CENT:
             denom_out = CoinDenomination::SIGMA_DENOM_0_1;
             break;
-        case COIN / 2:
+        case 50 * CENT:
             denom_out = CoinDenomination::SIGMA_DENOM_0_5;
             break;
         case 1 * COIN:
@@ -93,6 +110,9 @@ bool IntegerToDenomination(int64_t value, CoinDenomination& denom_out, CValidati
             break;
         case 10 * COIN:
             denom_out = CoinDenomination::SIGMA_DENOM_10;
+            break;
+        case 25 * COIN:
+            denom_out = CoinDenomination::SIGMA_DENOM_25;
             break;
         case 100 * COIN:
             denom_out = CoinDenomination::SIGMA_DENOM_100;
@@ -103,10 +123,12 @@ return true;
 
 void GetAllDenoms(std::vector<sigma::CoinDenomination>& denominations_out) {
     denominations_out.push_back(CoinDenomination::SIGMA_DENOM_100);
+    denominations_out.push_back(CoinDenomination::SIGMA_DENOM_25);
     denominations_out.push_back(CoinDenomination::SIGMA_DENOM_10);
     denominations_out.push_back(CoinDenomination::SIGMA_DENOM_1);
     denominations_out.push_back(CoinDenomination::SIGMA_DENOM_0_5);
     denominations_out.push_back(CoinDenomination::SIGMA_DENOM_0_1);
+    denominations_out.push_back(CoinDenomination::SIGMA_DENOM_0_05);
 }
 
 //class PublicCoin
@@ -256,6 +278,8 @@ namespace std {
 string to_string(::sigma::CoinDenomination denom)
 {
     switch (denom) {
+    case ::sigma::CoinDenomination::SIGMA_DENOM_0_05:
+        return "0.05";
     case ::sigma::CoinDenomination::SIGMA_DENOM_0_1:
         return "0.1";
     case ::sigma::CoinDenomination::SIGMA_DENOM_0_5:
@@ -264,6 +288,8 @@ string to_string(::sigma::CoinDenomination denom)
         return "1";
     case ::sigma::CoinDenomination::SIGMA_DENOM_10:
         return "10";
+    case ::sigma::CoinDenomination::SIGMA_DENOM_25:
+        return "25";
     case ::sigma::CoinDenomination::SIGMA_DENOM_100:
         return "100";
     default:

--- a/src/sigma/coin.h
+++ b/src/sigma/coin.h
@@ -12,10 +12,12 @@
 namespace sigma {
 
 enum class CoinDenomination : std::uint8_t {
+    SIGMA_DENOM_0_05 = 5,
     SIGMA_DENOM_0_1 = 0,
     SIGMA_DENOM_0_5 = 1,
     SIGMA_DENOM_1 = 2,
     SIGMA_DENOM_10 = 3,
+    SIGMA_DENOM_25 = 6,
     SIGMA_DENOM_100 = 4
 };
 

--- a/src/test/sigma_manymintspend_test.cpp
+++ b/src/test/sigma_manymintspend_test.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(sigma_mintspend_many)
     CBlock b;
     CWalletTx wtx;
 
-    std::vector<std::string> denominations = {"0.1", "0.5", "1", "10", "100"};
+    std::vector<std::string> denominations = {"0.05", "0.1", "0.5", "1", "10", "25", "100"};
 
     sigma::CSigmaState *sigmaState = sigma::CSigmaState::GetState();
 
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(sigma_mintspend_many)
 
     vector<pair<std::string, int>> denominationPairs;
 
-    for(int i = 0; i < 4; i++)
+    for(int i = 0; i < denominations.size() - 1; i++)
     {
         thirdPartyAddress = "";
         denominationsForTx.clear();
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(sigma_mintspend_many)
     thirdPartyAddress = "";
 
     // create transactions using the same denomination
-    for(int i = 0; i < 5; i++)
+    for(int i = 0; i < denominations.size(); i++)
     {
         denominationsForTx.clear();
         denominationsForTx.push_back(denominations[i]);
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_mintspend_usedinput){
     CBlock b;
     CWalletTx wtx;
 
-    std::vector<std::string> denominations = {"0.1", "0.5", "1", "10", "100"};
+    std::vector<std::string> denominations = {"0.05", "0.1", "0.5", "1", "10", "25", "100"};
 
     sigma::CSigmaState *sigmaState = sigma::CSigmaState::GetState();
 
@@ -295,8 +295,8 @@ BOOST_AUTO_TEST_CASE(zerocoin_mintspend_usedinput){
 
     // attempt to add a mixed input spend in one block, and use of the inputs into another tx in the next block.
     denominationsForTx.clear();
-    denominationsForTx.push_back(denominations[rand() % 5]);
-    denominationsForTx.push_back(denominations[rand() % 5]);
+    denominationsForTx.push_back(denominations[rand() % 7]);
+    denominationsForTx.push_back(denominations[rand() % 7]);
     printf("Testing denominations %s and %s\n", denominationsForTx[0].c_str(), denominationsForTx[1].c_str());
     string stringError;
 

--- a/src/test/sigma_mintspend_numinputs.cpp
+++ b/src/test/sigma_mintspend_numinputs.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(sigma_mintspend_numinputs)
     CWalletTx wtx;
     string stringError;
 
-    std::vector<std::string> denominations = {"0.1", "0.5", "1", "10", "100"};
+    std::vector<std::string> denominations = {"0.05", "0.1", "0.5", "1", "10", "25", "100"};
 
     // Test with small denominations to limit required coins.
     int denominationIndexA = 0; // 0.1

--- a/src/test/sigma_mintspend_test.cpp
+++ b/src/test/sigma_mintspend_test.cpp
@@ -34,15 +34,14 @@ BOOST_AUTO_TEST_CASE(sigma_mintspend_test)
     sigma::CSigmaState *sigmaState = sigma::CSigmaState::GetState();
     string denomination;
     vector<uint256> vtxid;
-    std::vector<string> denominations = {"0.1", "0.5", "1", "10", "100"};
+    std::vector<string> denominations = {"0.05", "0.1", "0.5", "1", "10", "25", "100"};
 
     // Create 400-200+1 = 201 new empty blocks. // consensus.nMintV3SigmaStartBlock = 400
     CreateAndProcessEmptyBlocks(201, scriptPubKey);
 
     // foreach denom from denominations
-    for(int i = 0; i < 5; i++)
+    for(auto denomination : denominations)
     {
-        denomination = denominations[i];
         printf("Testing denomination %s\n", denomination.c_str());
         string stringError;
         // Make sure that transactions get to mempool

--- a/src/test/sigma_partialspend_mempool_tests.cpp
+++ b/src/test/sigma_partialspend_mempool_tests.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(partialspend)
     sigma::CSigmaState* sigmaState = sigma::CSigmaState::GetState();
     std::vector<uint256> vtxid;
     // Can't test denomination 0.1, because we're unable to pay the fees.
-    std::vector<std::string> denominations = {"0.5", "1", "10", "100"};
+    std::vector<std::string> denominations = {"0.5", "1", "10", "25", "100"};
 
     // Get smallest denomination value
     std::vector<sigma::CoinDenomination> denoms;
@@ -103,13 +103,13 @@ BOOST_AUTO_TEST_CASE(partialspend)
         std::vector<CSigmaEntry> dSelected;
         std::vector<CSigmaEntry> dChanges;
 
-        CAmount denomAmount01;
-        sigma::DenominationToInteger(sigma::CoinDenomination::SIGMA_DENOM_0_1, denomAmount01);
+        CAmount denomAmount005;
+        sigma::DenominationToInteger(sigma::CoinDenomination::SIGMA_DENOM_0_05, denomAmount005);
 
         // Make dtx is not identical to tx
         std::vector<CRecipient> dupRecipients = {
             {GetScriptForDestination(randomAddr2.Get()), denomAmount / 2, false},
-            {GetScriptForDestination(randomAddr1.Get()), denomAmount / 2 - denomAmount01 - CENT, false},
+            {GetScriptForDestination(randomAddr1.Get()), denomAmount / 2 - denomAmount005 - CENT, false},
         };
         dtx = pwalletMain->CreateSigmaSpendTransaction(dupRecipients, dFee, dSelected, dChanges);
 
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(partialspend)
 
         std::vector<CRecipient> recipients = {
             {GetScriptForDestination(randomAddr1.Get()), denomAmount / 2, false},
-            {GetScriptForDestination(randomAddr2.Get()), denomAmount / 2 - denomAmount01 - CENT, false},
+            {GetScriptForDestination(randomAddr2.Get()), denomAmount / 2 - denomAmount005 - CENT, false},
         };
 
         // Create two spend transactions using the same mint.

--- a/src/wallet/test/sigma_tests.cpp
+++ b/src/wallet/test/sigma_tests.cpp
@@ -31,7 +31,7 @@ static std::list<std::pair<uint256, CBlockIndex>> blocks;
 
 struct WalletSigmaTestingSetup : WalletTestingSetup
 {
-    WalletSigmaTestingSetup() 
+    WalletSigmaTestingSetup()
         : sigmaState(sigma::CSigmaState::GetState())
     {
     }
@@ -188,18 +188,22 @@ static bool CheckSpend(const CTxIn& vin, const CSigmaEntry& expected)
 
 static CAmount GetCoinSetByDenominationAmount(
     std::vector<std::pair<sigma::CoinDenomination, int>>& coins,
+    int D005 = 0,
     int D01 = 0,
     int D05 = 0,
     int D1 = 0,
     int D10 = 0,
+    int D25 = 0,
     int D100 = 0)
 {
     coins.clear();
 
+    coins.push_back(std::pair<sigma::CoinDenomination, int>(sigma::CoinDenomination::SIGMA_DENOM_0_05, D005));
     coins.push_back(std::pair<sigma::CoinDenomination, int>(sigma::CoinDenomination::SIGMA_DENOM_0_1, D01));
     coins.push_back(std::pair<sigma::CoinDenomination, int>(sigma::CoinDenomination::SIGMA_DENOM_0_5, D05));
     coins.push_back(std::pair<sigma::CoinDenomination, int>(sigma::CoinDenomination::SIGMA_DENOM_1, D1));
     coins.push_back(std::pair<sigma::CoinDenomination, int>(sigma::CoinDenomination::SIGMA_DENOM_10, D10));
+    coins.push_back(std::pair<sigma::CoinDenomination, int>(sigma::CoinDenomination::SIGMA_DENOM_25, D25));
     coins.push_back(std::pair<sigma::CoinDenomination, int>(sigma::CoinDenomination::SIGMA_DENOM_100, D100));
 
     CAmount sum(0);
@@ -215,7 +219,7 @@ static CAmount GetCoinSetByDenominationAmount(
 static void AddOneCoinForEachGroup()
 {
     std::vector<std::pair<sigma::CoinDenomination, int>> coins;
-    GetCoinSetByDenominationAmount(coins, 1, 1, 1, 1, 1);
+    GetCoinSetByDenominationAmount(coins, 1, 1, 1, 1, 1, 1, 1);
     GenerateBlockWithCoins(coins, false);
 }
 
@@ -250,56 +254,54 @@ BOOST_AUTO_TEST_CASE(get_coin_no_coin)
 BOOST_AUTO_TEST_CASE(get_coin_different_denomination)
 {
     std::vector<std::pair<sigma::CoinDenomination, int>> newCoins;
-    GetCoinSetByDenominationAmount(newCoins, 2, 1, 1, 1, 1);
+    AddOneCoinForEachGroup();
+    GetCoinSetByDenominationAmount(newCoins, 1, 2, 1, 1, 1, 1, 1);
     GenerateBlockWithCoins(newCoins);
     GenerateEmptyBlocks(5);
 
-    CAmount require(111 * COIN + 7 * COIN / 10); // 111.7
+    CAmount require(13675 * CENT); // 136.75
 
     std::vector<CSigmaEntry> coins;
     std::vector<sigma::CoinDenomination> coinsToMint;
-    BOOST_CHECK_THROW(pwalletMain->GetCoinsToSpend(require, coins, coinsToMint), InsufficientFunds);
+    BOOST_CHECK_NO_THROW(pwalletMain->GetCoinsToSpend(require, coins, coinsToMint));
     sigmaState->Reset();
 }
 
 BOOST_AUTO_TEST_CASE(get_coin_round_up)
 {
     std::vector<std::pair<sigma::CoinDenomination, int>> newCoins;
-    GetCoinSetByDenominationAmount(newCoins, 5, 5, 5, 5, 5);
+    AddOneCoinForEachGroup();
+    GetCoinSetByDenominationAmount(newCoins, 5, 5, 5, 5, 5, 5, 5);
     GenerateBlockWithCoins(newCoins);
     GenerateEmptyBlocks(5);
 
-    // This must get rounded up to 111.8
-    CAmount require(111 * COIN + 7 * COIN / 10 + 5 * COIN / 100); // 111.75
+    // This must get rounded up to 111.65
+    CAmount require(11164 * CENT); // 111.64
 
     std::vector<CSigmaEntry> coinsToSpend;
     std::vector<sigma::CoinDenomination> coinsToMint;
     BOOST_CHECK_MESSAGE(pwalletMain->GetCoinsToSpend(require, coinsToSpend, coinsToMint),
       "Expect enough for requirement");
 
-    // We would expect to spend 100 + 10 + 1 + 1 and re-mint 0.1 + 0.1.
+    // We would expect to spend 100 + 10 + 1 + 0.5 + 0.1 + 0.05
     std::vector<std::pair<sigma::CoinDenomination, int>> expectedToSpend;
-    GetCoinSetByDenominationAmount(expectedToSpend, 0, 0, 2, 1, 1);
-
-    std::vector<std::pair<sigma::CoinDenomination, int>> expectedToMint;
-    GetCoinSetByDenominationAmount(expectedToMint, 2, 0, 0, 0, 0);
+    GetCoinSetByDenominationAmount(expectedToSpend, 1, 1, 1, 1, 1, 0, 1);
 
     BOOST_CHECK_MESSAGE(CheckDenominationCoins(expectedToSpend, coinsToSpend),
-      "Expected to get coins to spend with denominations 100 + 10 + 1 + 1.");
+      "Expected to get coins to spend with denominations 100 + 10 + 1 + 0.5 + 0.1 + 0.05.");
 
-    BOOST_CHECK_MESSAGE(CheckDenominationCoins(expectedToMint, coinsToMint),
-      "Expected to re-mint coins with denominations 0.1 + 0.1.");
     sigmaState->Reset();
 }
 
 BOOST_AUTO_TEST_CASE(get_coin_not_enough)
 {
+    AddOneCoinForEachGroup();
     std::vector<std::pair<sigma::CoinDenomination, int>> newCoins;
-    GetCoinSetByDenominationAmount(newCoins, 1, 1, 1, 1, 1);
+    GetCoinSetByDenominationAmount(newCoins, 1, 1, 1, 1, 1, 1, 1);
     GenerateBlockWithCoins(newCoins);
     GenerateEmptyBlocks(5);
 
-    CAmount require(11170 * CENT); // 111.7
+    CAmount require(13666 * CENT); // 136.66
 
     std::vector<CSigmaEntry> coins;
     std::vector<sigma::CoinDenomination> coinsToMint;
@@ -309,13 +311,14 @@ BOOST_AUTO_TEST_CASE(get_coin_not_enough)
 
 BOOST_AUTO_TEST_CASE(get_coin_cannot_spend_unconfirmed_coins)
 {
+    AddOneCoinForEachGroup();
     std::vector<std::pair<sigma::CoinDenomination, int>> newCoins;
-    GetCoinSetByDenominationAmount(newCoins, 1, 1, 1, 1, 1);
+    GetCoinSetByDenominationAmount(newCoins, 1, 1, 1, 1, 1, 1, 1);
     GenerateBlockWithCoins(newCoins);
     // Intentionally do not create 5 more blocks after this one, so coins can not be spent.
     // GenerateEmptyBlocks(5);
 
-    CAmount require(111 * COIN + 5 * COIN / 10); // 111.5
+    CAmount require(11150 * CENT); // 111.5
 
     std::vector<CSigmaEntry> coins;
     std::vector<sigma::CoinDenomination> coinsToMint;
@@ -327,7 +330,7 @@ BOOST_AUTO_TEST_CASE(get_coin_minimize_coins_spend_fit_amount)
 {
     std::vector<std::pair<sigma::CoinDenomination, int>> newCoins;
     AddOneCoinForEachGroup();
-    GetCoinSetByDenominationAmount(newCoins, 0, 0, 0, 10, 1);
+    GetCoinSetByDenominationAmount(newCoins, 0, 0, 0, 0, 10, 0, 1);
     GenerateBlockWithCoins(newCoins);
     GenerateEmptyBlocks(5);
 
@@ -339,7 +342,7 @@ BOOST_AUTO_TEST_CASE(get_coin_minimize_coins_spend_fit_amount)
       "Expect enough coin and equal to one SIGMA_DENOM_100");
 
     std::vector<std::pair<sigma::CoinDenomination, int>> expectedCoins;
-    GetCoinSetByDenominationAmount(expectedCoins, 0, 0, 0, 0, 1);
+    GetCoinSetByDenominationAmount(expectedCoins, 0, 0, 0, 0, 0, 0, 1);
 
     BOOST_CHECK_MESSAGE(CheckDenominationCoins(expectedCoins, coins),
       "Expect only one SIGMA_DENOM_100");
@@ -350,11 +353,11 @@ BOOST_AUTO_TEST_CASE(get_coin_minimize_coins_spend)
 {
     std::vector<std::pair<sigma::CoinDenomination, int>> newCoins;
     AddOneCoinForEachGroup();
-    GetCoinSetByDenominationAmount(newCoins, 1, 0, 7, 1, 1);
+    GetCoinSetByDenominationAmount(newCoins, 0, 1, 0, 2, 1, 0, 1);
     GenerateBlockWithCoins(newCoins);
     GenerateEmptyBlocks(5);
 
-    CAmount require(17 * COIN);
+    CAmount require(12 * COIN);
 
     std::vector<CSigmaEntry> coins;
     std::vector<sigma::CoinDenomination> coinsToMint;
@@ -362,10 +365,10 @@ BOOST_AUTO_TEST_CASE(get_coin_minimize_coins_spend)
       "Coins to spend value is not equal to required amount.");
 
     std::vector<std::pair<sigma::CoinDenomination, int>> expectedCoins;
-    GetCoinSetByDenominationAmount(expectedCoins, 0, 0, 7, 1, 0);
+    GetCoinSetByDenominationAmount(expectedCoins, 0, 0, 0, 2, 1, 0, 0);
 
     BOOST_CHECK_MESSAGE(CheckDenominationCoins(expectedCoins, coins),
-      "Expect only one SIGMA_DENOM_10 and 7 SIGMA_DENOM_1");
+      "Expect only one SIGMA_DENOM_10 and 2 SIGMA_DENOM_1");
     sigmaState->Reset();
 }
 
@@ -373,11 +376,11 @@ BOOST_AUTO_TEST_CASE(get_coin_choose_smallest_enough)
 {
     std::vector<std::pair<sigma::CoinDenomination, int>> newCoins;
     AddOneCoinForEachGroup();
-    GetCoinSetByDenominationAmount(newCoins, 1, 1, 1, 1, 1);
+    GetCoinSetByDenominationAmount(newCoins, 1, 1, 1, 1, 1, 1, 1);
     GenerateBlockWithCoins(newCoins);
     GenerateEmptyBlocks(5);
 
-    CAmount require(9 * COIN / 10); // 0.9
+    CAmount require(90 * CENT); // 0.9
 
     std::vector<CSigmaEntry> coins;
     std::vector<sigma::CoinDenomination> coinsToMint;
@@ -385,7 +388,7 @@ BOOST_AUTO_TEST_CASE(get_coin_choose_smallest_enough)
       "Expect enough coin and equal one SIGMA_DENOM_1");
 
     std::vector<std::pair<sigma::CoinDenomination, int>> expectedCoins;
-    GetCoinSetByDenominationAmount(expectedCoins, 0, 0, 1, 0, 0);
+    GetCoinSetByDenominationAmount(expectedCoins, 0, 0, 0, 1, 0, 0, 0);
 
     BOOST_CHECK_MESSAGE(CheckDenominationCoins(expectedCoins, coins),
       "Expect only one SIGMA_DENOM_1");
@@ -394,12 +397,13 @@ BOOST_AUTO_TEST_CASE(get_coin_choose_smallest_enough)
 
 BOOST_AUTO_TEST_CASE(get_coin_by_limit_max_to_1)
 {
+    AddOneCoinForEachGroup();
     std::vector<std::pair<sigma::CoinDenomination, int>> newCoins;
-    GetCoinSetByDenominationAmount(newCoins, 0, 0, 2, 0, 0);
+    GetCoinSetByDenominationAmount(newCoins, 0, 0, 0, 2, 0, 0, 0);
     GenerateBlockWithCoins(newCoins);
     GenerateEmptyBlocks(5);
 
-    CAmount require(1 * COIN + 10 * CENT); // 1.1
+    CAmount require(110 * CENT); // 1.1
 
     std::vector<CSigmaEntry> coins;
     std::vector<sigma::CoinDenomination> coinsToMint;
@@ -531,8 +535,8 @@ BOOST_AUTO_TEST_CASE(create_spend_with_coins_more_than_1)
     BOOST_CHECK(tx.vin.size() == 2);
 
     // 2 outputs to recipients 5 + 10 xzc
-    // 9 mints as changes, 1 * 4 + 0.5 * 1 + 0.1 * 4 xzc
-    BOOST_CHECK(tx.vout.size() == 11);
+    // 10 mints as changes, 1 * 4 + 0.5 * 1 + 0.1 * 4 + 0.05 xzc
+    BOOST_CHECK(tx.vout.size() == 12);
     BOOST_CHECK(fee > 0);
 
     BOOST_CHECK(selected.size() == 2);
@@ -551,7 +555,7 @@ BOOST_AUTO_TEST_CASE(create_spend_with_coins_more_than_1)
         return c + (v.scriptPubKey.IsSigmaMint() ? v.nValue : 0);
     });
 
-    BOOST_CHECK(remintsSum == 49 * COIN / 10);
+    BOOST_CHECK(remintsSum == 495 * CENT);
 
     // check walletdb
     std::list<CSigmaEntry> coinList;
@@ -568,9 +572,9 @@ BOOST_AUTO_TEST_CASE(create_spend_with_coins_more_than_1)
 
     coinList.clear();
     db.ListSigmaPubCoin(coinList);
-    BOOST_CHECK(coinList.size() == 11);
+    BOOST_CHECK(coinList.size() == 12);
     BOOST_CHECK(std::count_if(coinList.begin(), coinList.end(),
-        [](const CSigmaEntry& coin){return !coin.IsUsed;}) == 9);
+        [](const CSigmaEntry& coin){return !coin.IsUsed;}) == 10);
 
     spends.clear();
     db.ListCoinSpendSerial(spends);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2262,7 +2262,8 @@ bool CWallet::GetCoinsToSpend(
         throw std::invalid_argument(_("Amount limit is exceed max money"));
     }
 
-    // We have Coins denomination * 10^8, we divide last with 0.05 * 10^8 and add one coin of denomination 100
+    // We have Coins denomination * 10^8, we divide with 0.05 * 10^8 and add one coin of
+    // denomination 100 (also divide by 0.05 * 10^8)
     constexpr CAmount zeros(5000000);
 
     // Rounding, Anything below 0.05 zerocoin goes to the miners as a fee.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1189,7 +1189,7 @@ isminetype CWallet::IsMine(const CTxIn &txin) const {
         CDataStream serializedCoinSpend(
             std::vector<char>(txin.scriptSig.begin() + 1, txin.scriptSig.end()),
             SER_NETWORK, PROTOCOL_VERSION);
-        
+
         sigma::Params* sigmaParams = sigma::Params::get_default();
         sigma::CoinSpend spend(sigmaParams, serializedCoinSpend);
 
@@ -2262,10 +2262,10 @@ bool CWallet::GetCoinsToSpend(
         throw std::invalid_argument(_("Amount limit is exceed max money"));
     }
 
-    // We have Coins denomination * 10^8, we remove last 7 0's  and add one coin of denomination 100
-    constexpr CAmount zeros(10000000);
+    // We have Coins denomination * 10^8, we divide last with 0.05 * 10^8 and add one coin of denomination 100
+    constexpr CAmount zeros(5000000);
 
-    // Rounding, Anything below 0.1 zerocoin goes to the miners as a fee.
+    // Rounding, Anything below 0.05 zerocoin goes to the miners as a fee.
     int roundedRequired = required / zeros;
     if (required % zeros != 0) {
         ++roundedRequired;


### PR DESCRIPTION
- Add new denominations 0.5 and 25 XZC and the related function in `coin.cpp`.
- Update logic to choosing coins to spend.
- Update tests.
- Update RPC constraint
- Update QT coins summary
- Update mint constraint:
  1. user can mint any number that is multiple of 0.05 XZC (except 0.05 and amount that exceed balance)
  2. if user try to mint lower than 0.05 XZC, show error
  3. if user try to mint number that isn't multiple of 0.05 then ask user to spend rounded down amount. such as user mint 0.17 then round to 0.15

image for QT updates are provided in https://trello.com/c/sWOHgAnn/492-add-two-accumulator-denominations-005-and-25