### PR TITLE
Fix mint size in checking standard tx

### DIFF
--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -92,7 +92,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
     if (scriptPubKey.IsSigmaMint())
     {
         typeRet = TX_ZEROCOINMINTV3;
-        if(scriptPubKey.size() > 37) return false;
+        if(scriptPubKey.size() != 35) return false;
         vector<unsigned char> hashBytes(scriptPubKey.begin()+1, scriptPubKey.end());
         vSolutionsRet.push_back(hashBytes);
         return true;


### PR DESCRIPTION
size of valid mint is exactly equal to 35 bytes (1 byte of op_code and 34 bytes of Pedersen commitment)

https://trello.com/c/hWTHWjNz/362-enforce-max-script-size-for-each-spend