### PR TITLE
Fix mark spendable any coin which have at least 6 confirmations.

### DIFF
--- a/src/hdmint/tracker.cpp
+++ b/src/hdmint/tracker.cpp
@@ -444,7 +444,7 @@ bool CHDMintTracker::UpdateStatusInternal(const std::set<uint256>& setMempool, C
 
         // Check that the mint has correct used status
         if (mint.isUsed != isUsed) {
-            LogPrintf("%s : Set mint %s isUsed to %d\n", __func__, hashPubcoin.GetHex(), isUsed);    
+            LogPrintf("%s : Set mint %s isUsed to %d\n", __func__, hashPubcoin.GetHex(), isUsed);
             mint.isUsed = isUsed;
             isUpdated = true;
         }
@@ -501,7 +501,7 @@ bool CHDMintTracker::UpdateMints(std::set<uint256> serialHashes, bool fReset, bo
         }
 
         if((!fSelection) ||
-            (fSelection && (serialHashes.find(dMint.GetSerialHash()) != serialHashes.end()))){ 
+            (fSelection && (serialHashes.find(dMint.GetSerialHash()) != serialHashes.end()))){
             Add(dMint, true, false, zerocoinWallet);
         }
     }
@@ -510,10 +510,10 @@ bool CHDMintTracker::UpdateMints(std::set<uint256> serialHashes, bool fReset, bo
     return true;
 }
 
-list<CSigmaEntry> CHDMintTracker::MintsAsZerocoinEntries(){
+list<CSigmaEntry> CHDMintTracker::MintsAsZerocoinEntries(bool fUnusedOnly, bool fMatureOnly){
     list <CSigmaEntry> listPubcoin;
     CWalletDB walletdb(strWalletFile);
-    std::vector<CMintMeta> vecMists = ListMints();
+    std::vector<CMintMeta> vecMists = ListMints(fUnusedOnly, fMatureOnly);
     list<CMintMeta> listMints(vecMists.begin(), vecMists.end());
     for (const CMintMeta& mint : listMints) {
         CSigmaEntry entry;

--- a/src/hdmint/tracker.h
+++ b/src/hdmint/tracker.h
@@ -40,7 +40,7 @@ public:
     std::list<CMintMeta> GetMints(bool fConfirmedOnly, bool fInactive = true) const;
     CAmount GetUnconfirmedBalance() const;
     bool MintMetaToZerocoinEntries(std::list <CSigmaEntry>& entries, std::list<CMintMeta> setMints) const;
-    list<CSigmaEntry> MintsAsZerocoinEntries();
+    list<CSigmaEntry> MintsAsZerocoinEntries(bool fUnusedOnly = true, bool fMatureOnly = true);
     std::vector<CMintMeta> ListMints(bool fUnusedOnly = true, bool fMatureOnly = true, bool fUpdateStatus = true, bool fWrongSeed = false);
     void RemovePending(const uint256& txid);
     void SetPubcoinUsed(const uint256& hashPubcoin, const uint256& txid);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -224,6 +224,7 @@ public:
     void sigmaMint(const CAmount& n, const CCoinControl *coinControl = NULL);
     void checkSigmaAmount(bool forced);
 
+    std::vector<CSigmaEntry> GetUnsafeCoins(const CCoinControl* coinControl = NULL);
 
 private:
     CWallet *wallet;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2229,7 +2229,7 @@ CAmount CWallet::SelectSpendCoinsForAmount(
     return required - val;
 }
 
-std::list<CSigmaEntry> CWallet::GetAvailableCoins(const CCoinControl *coinControl) const {
+std::list<CSigmaEntry> CWallet::GetAvailableCoins(const CCoinControl *coinControl, bool includeUnsafe) const {
     LOCK2(cs_main, cs_wallet);
     CWalletDB walletdb(strWalletFile);
     std::list<CSigmaEntry> coins;
@@ -2247,7 +2247,7 @@ std::list<CSigmaEntry> CWallet::GetAvailableCoins(const CCoinControl *coinContro
     // above them, after they were minted.
     // Also filter out used coins.
     // Finally filter out coins that have not been selected from CoinControl should that be used
-    coins.remove_if([lockedCoins, coinControl](const CSigmaEntry& coin) {
+    coins.remove_if([lockedCoins, coinControl, includeUnsafe](const CSigmaEntry& coin) {
         sigma::CSigmaState* sigmaState = sigma::CSigmaState::GetState();
         if (coin.IsUsed)
             return true;
@@ -2268,7 +2268,7 @@ std::list<CSigmaEntry> CWallet::GetAvailableCoins(const CCoinControl *coinContro
             coinOuts
         );
 
-        if (coinOuts.size() < 2) {
+        if (!includeUnsafe && coinOuts.size() < 2) {
             return true;
         }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -895,7 +895,7 @@ public:
 
     // Returns a list of unspent and verified coins, I.E. coins which are ready
     // to be spent.
-    std::list<CSigmaEntry> GetAvailableCoins(const CCoinControl *coinControl = NULL) const;
+    std::list<CSigmaEntry> GetAvailableCoins(const CCoinControl *coinControl = NULL, bool includeUnsafe = false) const;
 
     /** \brief Selects coins to spend, and coins to re-mint based on the required amount to spend, provided by the user. As the lower denomination now is 0.1 zcoin, user's request will be rounded up to the nearest 0.1. This difference between the user's requested value, and the actually spent value will be left to the miners as a fee.
      * \param[in] required Required amount to spend.


### PR DESCRIPTION
current behavior
- mark a coin as spendable only if have 6 confirms which is not a single coin in the group.

expected behavior
- mark any coin as spendable only if have 6 confirms
- If coins in wallet not enough to spend will should error not enough balance and then show all coins that mark as spendable but can't not spend because of privacy issue. 

for more information about notification can take a look more in the card https://trello.com/c/M403vjcG/472-fix-sigma-tab-show-wrong-balance
the situation is have only 2 coins in global state(1 and 0.5) and try to spend 1.3 XZC. Message error will tell user what denomination(s) need to wait more other user to mint.