### PR TITLE
Add regtests for sigma mint spend with 'watchonly' address

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -146,6 +146,7 @@ testScripts = [
     # 'signmessages.py',
     # 'p2p-compactblocks.py',
     # 'nulldummy.py',
+    'sigma_spend_gettransaction.py',
     'sigma_spend_validation.py',
     'sigma_spend_extra_validation.py',
     'sigma_mint_validation.py',

--- a/qa/rpc-tests/sigma_spend_gettransaction.py
+++ b/qa/rpc-tests/sigma_spend_gettransaction.py
@@ -39,7 +39,7 @@ class SigmaSpendGettransactionTest(BitcoinTestFramework):
         spendto_wo_tx = self.nodes[0].gettransaction(spendto_wo_id)
 
         assert spendto_wo_tx['amount'] == Decimal('-1')
-        assert spendto_wo_tx['fee'] == Decimal('-0.05')
+        assert spendto_wo_tx['fee'] < Decimal('0')
         assert isinstance(spendto_wo_tx['details'], list)
         assert len(spendto_wo_tx['details']) == 1
         assert spendto_wo_tx['details'][0]['involvesWatchonly']
@@ -49,7 +49,7 @@ class SigmaSpendGettransactionTest(BitcoinTestFramework):
         spendto_wo_and_valid_tx = self.nodes[0].gettransaction(spendto_wo_and_valid_id)
 
         assert spendto_wo_and_valid_tx['amount'] == Decimal('-1')
-        assert spendto_wo_and_valid_tx['fee'] == Decimal('-0.05')
+        assert spendto_wo_and_valid_tx['fee'] < Decimal('0')
         assert isinstance(spendto_wo_and_valid_tx['details'], list)
         assert len(spendto_wo_and_valid_tx['details']) == 3
 

--- a/qa/rpc-tests/sigma_spend_gettransaction.py
+++ b/qa/rpc-tests/sigma_spend_gettransaction.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+from decimal import *
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class SigmaSpendGettransactionTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 4
+        self.setup_clean_chain = True
+
+    def setup_nodes(self):
+        # This test requires mocktime
+        enable_mocktime()
+        return start_nodes(self.num_nodes, self.options.tmpdir)
+
+    def run_test(self):
+        # Decimal formating: 6 digits for balance will be enought 000.000
+        getcontext().prec = 6
+        self.nodes[0].generate(400)
+        self.sync_all()
+
+        # get a watch only address
+        watchonly_address = self.nodes[3].getnewaddress()
+        watchonly_pubkey = self.nodes[3].validateaddress(watchonly_address)["pubkey"]
+        self.nodes[0].importpubkey(watchonly_pubkey, "", True)
+
+        valid_address = self.nodes[0].getnewaddress()
+
+        for _ in range(10):
+            self.nodes[0].mint(1)
+
+        self.nodes[0].generate(10)
+        self.sync_all()
+
+        # case 1: Spend many with watchonly address
+        spendto_wo_id = self.nodes[0].spendmany("", {watchonly_address: 1})
+        spendto_wo_tx = self.nodes[0].gettransaction(spendto_wo_id)
+
+        assert spendto_wo_tx['amount'] == Decimal('-1')
+        assert spendto_wo_tx['fee'] == Decimal('-0.05')
+        assert isinstance(spendto_wo_tx['details'], list)
+        assert len(spendto_wo_tx['details']) == 1
+        assert spendto_wo_tx['details'][0]['involvesWatchonly']
+
+        # case 2: Spend many with watchonly address and valid address
+        spendto_wo_and_valid_id = self.nodes[0].spendmany("", {watchonly_address: 1, valid_address: 2})
+        spendto_wo_and_valid_tx = self.nodes[0].gettransaction(spendto_wo_and_valid_id)
+
+        assert spendto_wo_and_valid_tx['amount'] == Decimal('-1')
+        assert spendto_wo_and_valid_tx['fee'] == Decimal('-0.05')
+        assert isinstance(spendto_wo_and_valid_tx['details'], list)
+        assert len(spendto_wo_and_valid_tx['details']) == 3
+
+        involves_watch_only_count = 0
+        for detial in spendto_wo_and_valid_tx['details']:
+            if 'involvesWatchonly' in detial and bool(detial['involvesWatchonly']):
+                involves_watch_only_count += 1
+
+        assert involves_watch_only_count == 1
+
+        # case 3: spend many with watchonly address and invalid address
+        assert_raises(JSONRPCException, self.nodes[0].spendmany, ["", {watchonly_address: 1, 'invalidaddress': 2}])
+
+if __name__ == '__main__':
+    SigmaSpendGettransactionTest().main()
+
+


### PR DESCRIPTION
add reg test following this card https://trello.com/c/tkaqvuh0/378-add-regtests-for-sigma-mint-spend-with-watchonly-address-t15d1