### PR TITLE
Fix a crash that occurred intermittently on bootup.

### DIFF
--- a/src/client-api/wallet.cpp
+++ b/src/client-api/wallet.cpp
@@ -332,8 +332,7 @@ void ListAPITransactions(const CWalletTx& wtx, UniValue& ret, const isminefilter
                 else
                     category = "mined";
             }
-            else if(wtx.vin[r.vout].IsZerocoinSpend() ||
-                    wtx.vin[r.vout].IsSigmaSpend()){
+            else if(wtx.vin.size() > r.vout && (wtx.vin[r.vout].IsZerocoinSpend() || wtx.vin[r.vout].IsSigmaSpend())) {
                 category = "spendIn";
             }
             else {


### PR DESCRIPTION
This fixes a crash that occurred on boot about 50% of the time on my system. I'm not entirely sure the behaviour of assuming the transaction is *not* a spendIn in the event that the vector index would be out of bounds is semantically correct; please give that a look.

@riordant 