### PR TITLE
Fix show wrong denominations amount

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -214,7 +214,7 @@ void WalletModel::checkSigmaAmount(bool forced)
         std::list<CSigmaEntry> coins;
         CWalletDB(wallet->strWalletFile).ListSigmaPubCoin(coins);
 
-        auto hdmintCoins = wallet->hdMintTracker->MintsAsZerocoinEntries();
+        auto hdmintCoins = wallet->hdMintTracker->MintsAsZerocoinEntries(true, false);
         coins.insert(coins.end(), hdmintCoins.begin(), hdmintCoins.end());
 
         std::vector<CSigmaEntry> spendable, pending;


### PR DESCRIPTION
Fix bug that some coins is not shown when it's confirmed.

The problem is function to get coin list do not return immature coins by default.