### PR TITLE
MTP verification performance tuning

### DIFF
--- a/src/crypto/MerkleTreeProof/blake2/blake2-impl.h
+++ b/src/crypto/MerkleTreeProof/blake2/blake2-impl.h
@@ -66,16 +66,36 @@ static BLAKE2_INLINE uint64_t load64(const void *src) {
     memcpy(&w, src, sizeof w);
     return w;
 #else
-    const uint8_t *p = (const uint8_t *)src;
-    uint64_t w = *p++;
-    w |= (uint64_t)(*p++) << 8;
-    w |= (uint64_t)(*p++) << 16;
-    w |= (uint64_t)(*p++) << 24;
-    w |= (uint64_t)(*p++) << 32;
-    w |= (uint64_t)(*p++) << 40;
-    w |= (uint64_t)(*p++) << 48;
-    w |= (uint64_t)(*p++) << 56;
+        const uint8_t *p = (const uint8_t *)src;
+        uint64_t w = *p++;
+        w |= (uint64_t)(*p++) << 8;
+        w |= (uint64_t)(*p++) << 16;
+        w |= (uint64_t)(*p++) << 24;
+        w |= (uint64_t)(*p++) << 32;
+        w |= (uint64_t)(*p++) << 40;
+        w |= (uint64_t)(*p++) << 48;
+        w |= (uint64_t)(*p++) << 56;
     return w;
+#endif
+}
+
+static BLAKE2_INLINE void load64_many(uint64_t * dest, const void *src, size_t number_of_elements) {
+#if defined(NATIVE_LITTLE_ENDIAN)
+    memcpy(dest, src, sizeof(uint64_t) * number_of_elements);
+#else
+    for(size_t i = 0; i < number_of_elements; ++i) {
+        const uint8_t *p = (const uint8_t *)src + i * sizeof(uint64_t);
+        uint64_t w = *p++;
+        w |= (uint64_t)(*p++) << 8;
+        w |= (uint64_t)(*p++) << 16;
+        w |= (uint64_t)(*p++) << 24;
+        w |= (uint64_t)(*p++) << 32;
+        w |= (uint64_t)(*p++) << 40;
+        w |= (uint64_t)(*p++) << 48;
+        w |= (uint64_t)(*p++) << 56;
+        dest = w;
+        ++dest;
+    }
 #endif
 }
 

--- a/src/crypto/MerkleTreeProof/blake2/blake2-impl.h
+++ b/src/crypto/MerkleTreeProof/blake2/blake2-impl.h
@@ -66,15 +66,15 @@ static BLAKE2_INLINE uint64_t load64(const void *src) {
     memcpy(&w, src, sizeof w);
     return w;
 #else
-        const uint8_t *p = (const uint8_t *)src;
-        uint64_t w = *p++;
-        w |= (uint64_t)(*p++) << 8;
-        w |= (uint64_t)(*p++) << 16;
-        w |= (uint64_t)(*p++) << 24;
-        w |= (uint64_t)(*p++) << 32;
-        w |= (uint64_t)(*p++) << 40;
-        w |= (uint64_t)(*p++) << 48;
-        w |= (uint64_t)(*p++) << 56;
+    const uint8_t *p = (const uint8_t *)src;
+    uint64_t w = *p++;
+    w |= (uint64_t)(*p++) << 8;
+    w |= (uint64_t)(*p++) << 16;
+    w |= (uint64_t)(*p++) << 24;
+    w |= (uint64_t)(*p++) << 32;
+    w |= (uint64_t)(*p++) << 40;
+    w |= (uint64_t)(*p++) << 48;
+    w |= (uint64_t)(*p++) << 56;
     return w;
 #endif
 }

--- a/src/crypto/MerkleTreeProof/blake2/blake2b.c
+++ b/src/crypto/MerkleTreeProof/blake2/blake2b.c
@@ -226,13 +226,15 @@ static void blake2b_4r_compress(blake2b_state *S, const uint8_t *block) {
     uint64_t v[16];
     unsigned int i, r;
 
-    for (i = 0; i < 16; ++i) {
-        m[i] = load64(block + i * sizeof(m[i]));
-    }
+    load64_many(m, block, 16);
+//    for (i = 0; i < 16; ++i) {
+//        m[i] = load64(block + i * sizeof(m[i]));
+//    }
 
-    for (i = 0; i < 8; ++i) {
-        v[i] = S->h[i];
-    }
+    memcpy(v, S->h, 8 * sizeof(v[0]));
+//    for (i = 0; i < 8; ++i) {
+//        v[i] = S->h[i];
+//    }
 
     v[8] = blake2b_IV[0];
     v[9] = blake2b_IV[1];

--- a/src/crypto/MerkleTreeProof/blake2/blake2b.c
+++ b/src/crypto/MerkleTreeProof/blake2/blake2b.c
@@ -227,14 +227,8 @@ static void blake2b_4r_compress(blake2b_state *S, const uint8_t *block) {
     unsigned int i, r;
 
     load64_many(m, block, 16);
-//    for (i = 0; i < 16; ++i) {
-//        m[i] = load64(block + i * sizeof(m[i]));
-//    }
 
     memcpy(v, S->h, 8 * sizeof(v[0]));
-//    for (i = 0; i < 8; ++i) {
-//        v[i] = S->h[i];
-//    }
 
     v[8] = blake2b_IV[0];
     v[9] = blake2b_IV[1];

--- a/src/crypto/MerkleTreeProof/merkle-tree.cpp
+++ b/src/crypto/MerkleTreeProof/merkle-tree.cpp
@@ -70,6 +70,7 @@ MerkleTree::Buffer MerkleTree::combinedHash(const Buffer& first,
         const Buffer& second, bool preserveOrder)
 {
     Buffer buffer;
+    buffer.reserve(first.size() + second.size());
     if (preserveOrder || (first > second)) {
         std::copy(first.begin(), first.end(), std::back_inserter(buffer));
         std::copy(second.begin(), second.end(), std::back_inserter(buffer));

--- a/src/crypto/MerkleTreeProof/mtp.cpp
+++ b/src/crypto/MerkleTreeProof/mtp.cpp
@@ -214,9 +214,8 @@ bool mtp_verify(const char* input, const uint32_t target,
         uint256 *mtpHashValue)
 {
     MerkleTree::Elements proof_blocks[L * 3];
-    MerkleTree::Buffer root;
+    MerkleTree::Buffer const root(&hash_root_mtp[0], &hash_root_mtp[16]);
     block blocks[L * 2];
-    root.insert(root.begin(), &hash_root_mtp[0], &hash_root_mtp[16]);
     for (int i = 0; i < (L * 3); ++i) {
         proof_blocks[i] = proof_mtp[i];
     }

--- a/src/crypto/MerkleTreeProof/mtp.cpp
+++ b/src/crypto/MerkleTreeProof/mtp.cpp
@@ -213,12 +213,8 @@ bool mtp_verify(const char* input, const uint32_t target,
         uint256 pow_limit,
         uint256 *mtpHashValue)
 {
-    MerkleTree::Elements proof_blocks[L * 3];
     MerkleTree::Buffer const root(&hash_root_mtp[0], &hash_root_mtp[16]);
     block blocks[L * 2];
-    for (int i = 0; i < (L * 3); ++i) {
-        proof_blocks[i] = proof_mtp[i];
-    }
     for(int i = 0; i < (L * 2); ++i) {
         std::memcpy(blocks[i].v, block_mtp[i],
                 sizeof(uint64_t) * ARGON2_QWORDS_IN_BLOCK);
@@ -340,7 +336,7 @@ bool mtp_verify(const char* input, const uint32_t target,
         compute_blake2b(prev_block, digest_prev);
         MerkleTree::Buffer hash_prev(digest_prev,
                 digest_prev + sizeof(digest_prev));
-        if (!MerkleTree::checkProofOrdered(proof_blocks[(j * 3) - 2],
+        if (!MerkleTree::checkProofOrdered(proof_mtp[(j * 3) - 2],
                     root, hash_prev, ij_prev + 1)) {
             LogPrintf("error : checkProofOrdered in x[ij_prev]\n");
             return false;
@@ -371,7 +367,7 @@ bool mtp_verify(const char* input, const uint32_t target,
         uint8_t digest_ref[MERKLE_TREE_ELEMENT_SIZE_B];
         compute_blake2b(ref_block, digest_ref);
         MerkleTree::Buffer hash_ref(digest_ref, digest_ref + sizeof(digest_ref));
-        if (!MerkleTree::checkProofOrdered(proof_blocks[(j * 3) - 1],
+        if (!MerkleTree::checkProofOrdered(proof_mtp[(j * 3) - 1],
                     root, hash_ref, computed_ref_block + 1)) {
             LogPrintf("error : checkProofOrdered in x[ij_ref]\n");
             return false;
@@ -388,7 +384,7 @@ bool mtp_verify(const char* input, const uint32_t target,
         compute_blake2b(block_ij, digest_ij);
         MerkleTree::Buffer hash_ij(digest_ij, digest_ij + sizeof(digest_ij));
 
-        if (!MerkleTree::checkProofOrdered(proof_blocks[(j * 3) - 3], root,
+        if (!MerkleTree::checkProofOrdered(proof_mtp[(j * 3) - 3], root,
                     hash_ij, ij + 1)) {
             LogPrintf("error : checkProofOrdered in x[ij]\n");
             return false;


### PR DESCRIPTION
It makes the reindexing of MTP blocks 20-30% faster by removing unnecessary copying, preallocating memory and optimizing some memory access.