### PR TITLE
Fix for Sigma list

### DIFF
--- a/src/hdmint/tracker.cpp
+++ b/src/hdmint/tracker.cpp
@@ -437,8 +437,6 @@ bool CHDMintTracker::UpdateMetaStatus(const std::set<uint256>& setMempool, CMint
         // Check the transaction associated with this mint
         if (!IsInitialBlockDownload() && !GetTransaction(mint.txid, tx, ::Params().GetConsensus(), hashBlock, true)) {
             LogPrintf("%s : Failed to find tx for mint txid=%s\n", __func__, mint.txid.GetHex());
-            mint.isArchived = true;
-            Archive(mint);
             return true;
         }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -793,6 +793,7 @@ void ThreadImport(std::vector <boost::filesystem::path> vImportFiles) {
 #ifdef ENABLE_WALLET
     if (!GetBoolArg("-disablewallet", false)) {
         //Load zerocoin mint hashes to memory
+        LogPrintf("Loading mints to wallet..\n");
         pwalletMain->hdMintTracker->Init();
         zwalletMain->LoadMintPoolFromDB();
     }


### PR DESCRIPTION
Fix for mempool transactions not showing in Sigma list following restart or encryption.