### PR TITLE
List from mempool fix

### DIFF
--- a/src/hdmint/tracker.h
+++ b/src/hdmint/tracker.h
@@ -19,6 +19,7 @@ private:
     std::string strWalletFile;
     std::map<uint256, CMintMeta> mapSerialHashes;
     std::map<uint256, uint256> mapPendingSpends; //serialhash, txid of spend
+    bool IsMempoolSpendOurs(const std::set<uint256>& setMempool, const uint256& hashSerial);
     bool UpdateMetaStatus(const std::set<uint256>& setMempool, CMintMeta& mint);
 public:
     CHDMintTracker(std::string strWalletFile);
@@ -43,7 +44,7 @@ public:
     void UpdateMintStateFromBlock(const std::vector<sigma::PublicCoin>& mints);
     void UpdateSpendStateFromBlock(const sigma::spend_info_container& spentSerials);
     list<CSigmaEntry> MintsAsZerocoinEntries(bool fUnusedOnly = true, bool fMatureOnly = true);
-    std::vector<CMintMeta> ListMints(bool fUnusedOnly = true, bool fMatureOnly = true, bool fUpdateStatus = true, bool fWrongSeed = false);
+    std::vector<CMintMeta> ListMints(bool fUnusedOnly = true, bool fMatureOnly = true, bool fUpdateStatus = true, bool fLoad = false, bool fWrongSeed = false);
     void RemovePending(const uint256& txid);
     void SetPubcoinUsed(const uint256& hashPubcoin, const uint256& txid);
     void SetPubcoinNotUsed(const uint256& hashPubcoin);

--- a/src/hdmint/tracker.h
+++ b/src/hdmint/tracker.h
@@ -43,6 +43,7 @@ public:
     void UpdateFromBlock(const std::list<std::pair<uint256, MintPoolEntry>>& mintPoolEntries, const std::vector<CMintMeta>& updatedMeta);
     void UpdateMintStateFromBlock(const std::vector<sigma::PublicCoin>& mints);
     void UpdateSpendStateFromBlock(const sigma::spend_info_container& spentSerials);
+    void UpdateSpendStateFromMempool(const vector<Scalar>& spentSerials);
     list<CSigmaEntry> MintsAsZerocoinEntries(bool fUnusedOnly = true, bool fMatureOnly = true);
     std::vector<CMintMeta> ListMints(bool fUnusedOnly = true, bool fMatureOnly = true, bool fUpdateStatus = true, bool fLoad = false, bool fWrongSeed = false);
     void RemovePending(const uint256& txid);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -866,6 +866,9 @@ void ThreadImport(std::vector <boost::filesystem::path> vImportFiles) {
     if (!GetBoolArg("-disablewallet", false)) {
         zwalletMain->SyncWithChain();
     }
+    if (GetBoolArg("-zapwallettxes", false)) {
+        pwalletMain->hdMintTracker->ListMints();
+    }
 #endif
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1800,10 +1800,12 @@ bool AcceptToMemoryPoolWorker(
 
     if (tx.IsZerocoinSpend() && markZcoinSpendTransactionSerial)
         zcState->AddSpendToMempool(zcSpendSerials, hash);
-    if (tx.IsSigmaSpend() && markZcoinSpendTransactionSerial)
+    if (tx.IsSigmaSpend() && markZcoinSpendTransactionSerial){
         sigmaState->AddSpendToMempool(zcSpendSerialsV3, hash);
-
+        pwalletMain->hdMintTracker->UpdateSpendStateFromMempool(zcSpendSerialsV3);
+    }
     SyncWithWallets(tx, NULL, NULL);
+
     LogPrintf("AcceptToMemoryPoolWorker -> OK\n");
 
     return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1800,8 +1800,10 @@ bool AcceptToMemoryPoolWorker(
 
     if (tx.IsZerocoinSpend() && markZcoinSpendTransactionSerial)
         zcState->AddSpendToMempool(zcSpendSerials, hash);
-    if (tx.IsSigmaSpend() && markZcoinSpendTransactionSerial){
-        sigmaState->AddSpendToMempool(zcSpendSerialsV3, hash);
+    if (tx.IsSigmaSpend()){
+        if(markZcoinSpendTransactionSerial)
+            sigmaState->AddSpendToMempool(zcSpendSerialsV3, hash);
+        LogPrintf("Updating mint tracker state from Mempool..");
         pwalletMain->hdMintTracker->UpdateSpendStateFromMempool(zcSpendSerialsV3);
     }
     SyncWithWallets(tx, NULL, NULL);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2888,7 +2888,7 @@ void CWallet::ListAvailableCoinsMintCoins(vector <COutput> &vCoins, bool fOnlyCo
 
 void CWallet::ListAvailableSigmaMintCoins(vector<COutput> &vCoins, bool fOnlyConfirmed) const {
     vCoins.clear();
-    LOCK2(cs_main, pwalletMain->cs_wallet);
+    LOCK2(cs_main, cs_wallet);
     list<CSigmaEntry> listOwnCoins;
     CWalletDB walletdb(pwalletMain->strWalletFile);
     listOwnCoins = pwalletMain->hdMintTracker->MintsAsZerocoinEntries();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2888,7 +2888,7 @@ void CWallet::ListAvailableCoinsMintCoins(vector <COutput> &vCoins, bool fOnlyCo
 
 void CWallet::ListAvailableSigmaMintCoins(vector<COutput> &vCoins, bool fOnlyConfirmed) const {
     vCoins.clear();
-    LOCK(cs_wallet);
+    LOCK2(cs_main, pwalletMain->cs_wallet);
     list<CSigmaEntry> listOwnCoins;
     CWalletDB walletdb(pwalletMain->strWalletFile);
     listOwnCoins = pwalletMain->hdMintTracker->MintsAsZerocoinEntries();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6922,7 +6922,7 @@ bool CWallet::CommitSigmaTransaction(CWalletTx& wtxNew, std::vector<CSigmaEntry>
             throw std::runtime_error(_("Failed to write coin serial number into wallet"));
         }
 
-        //Set spent mint as used
+        //Set spent mint as used in memory
         uint256 hashPubcoin = primitives::GetPubCoinValueHash(coin.value);
         pwalletMain->hdMintTracker->SetPubcoinUsed(hashPubcoin, wtxNew.GetHash());
         CMintMeta metaCheck = pwalletMain->hdMintTracker->GetMetaFromPubcoin(hashPubcoin);
@@ -6930,6 +6930,9 @@ bool CWallet::CommitSigmaTransaction(CWalletTx& wtxNew, std::vector<CSigmaEntry>
             string strError = "Error, mint with pubcoin hash " + hashPubcoin.GetHex() + " did not get marked as used";
             LogPrintf("SpendZerocoin() : %s\n", strError.c_str());
         }
+
+        //Set spent mint as used in DB
+        pwalletMain->hdMintTracker->UpdateState(metaCheck);
 
         // update CSigmaEntry
         coin.IsUsed = true;


### PR DESCRIPTION
Fixes issue where if the user closes wallet without spend mined (ie. mempool entry), on restart, spend still displays as "Spendable"