### PR TITLE
Disable sigma on legacy wallet

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -148,6 +148,8 @@ testScripts = [
     # 'nulldummy.py',
     'transations_verification_after_restart.py',
     'sigma_remint_lockedwallet.py',
+    'enable_hdsigma.py',
+    'disable_nonhdsigma.py',
     'sigma_zapsigmamints.py',
     'sigma_remint.py',
     'sigma_remint_validation.py',

--- a/qa/rpc-tests/disable_nonhdsigma.py
+++ b/qa/rpc-tests/disable_nonhdsigma.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Zcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import (
+    start_nodes,
+    assert_raises_message,
+)
+
+class DisableNonHDSigmaTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [["-usehd=0"]])
+
+    def assert_disable_nonhd(self, fn, args = []):
+        assert_raises_message(JSONRPCException, "sigma mint/spend is not allowed for legacy wallet", \
+            fn, args)
+
+    def run_test(self):
+        self.nodes[0].generate(500)
+        node = self.nodes[0]
+
+        fn_to_tests = [
+            node.listsigmamints,
+            node.listsigmapubcoins,
+            node.listsigmaspends,
+            node.mint,
+            node.remintzerocointosigma,
+            node.setsigmamintstatus,
+            node.spendmany,
+        ]
+
+        for fn in fn_to_tests:
+            self.assert_disable_nonhd(fn)
+
+if __name__ == '__main__':
+    DisableNonHDSigmaTest().main()

--- a/qa/rpc-tests/enable_hdsigma.py
+++ b/qa/rpc-tests/enable_hdsigma.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Zcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import (
+    start_nodes,
+    assert_raises_message,
+)
+
+class EnableHDSigmaTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [["-usehd=1"]])
+
+    def assert_enable_hd(self, fn, args = []):
+        try:
+            fn(args)
+        except JSONRPCException as e:
+            msg = e.error["message"]
+            assert msg != "sigma mint/spend is not allowed for legacy wallet"
+
+    def run_test(self):
+        self.nodes[0].generate(500)
+        node = self.nodes[0]
+
+        fn_to_tests = [
+            node.listsigmamints,
+            node.listsigmapubcoins,
+            node.listsigmaspends,
+            node.mint,
+            node.remintzerocointosigma,
+            node.setsigmamintstatus,
+            node.spendmany,
+        ]
+
+        for fn in fn_to_tests:
+            self.assert_enable_hd(fn)
+
+if __name__ == '__main__':
+    EnableHDSigmaTest().main()

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -97,6 +97,7 @@ QT_TS = \
 QT_FORMS_UI = \
   qt/forms/addressbookpage.ui \
   qt/forms/zerocoinpage.ui \
+  qt/forms/blanksigmadialog.ui \
   qt/forms/sigmadialog.ui \
   qt/forms/sigmacoincontroldialog.ui \
   qt/forms/askpassphrasedialog.ui \

--- a/src/hdmint/tracker.cpp
+++ b/src/hdmint/tracker.cpp
@@ -475,7 +475,7 @@ bool CHDMintTracker::UpdateMetaStatus(const std::set<uint256>& setMempool, CMint
 }
 
 void CHDMintTracker::UpdateFromBlock(const std::list<std::pair<uint256, MintPoolEntry>>& mintPoolEntries, const std::vector<CMintMeta>& updatedMeta){
-    if(mintPoolEntries.size()>0)
+    if(mintPoolEntries.size()>0 && zwalletMain)
         zwalletMain->SyncWithChain(false, mintPoolEntries);
 
     //overwrite any updates

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -794,8 +794,8 @@ void ThreadImport(std::vector <boost::filesystem::path> vImportFiles) {
     if (!GetBoolArg("-disablewallet", false)) {
         //Load zerocoin mint hashes to memory
         LogPrintf("Loading mints to wallet..\n");
-        pwalletMain->hdMintTracker->Init();
         if (zwalletMain) {
+            pwalletMain->hdMintTracker->Init();
             zwalletMain->LoadMintPoolFromDB();
         }
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -795,7 +795,9 @@ void ThreadImport(std::vector <boost::filesystem::path> vImportFiles) {
         //Load zerocoin mint hashes to memory
         LogPrintf("Loading mints to wallet..\n");
         pwalletMain->hdMintTracker->Init();
-        zwalletMain->LoadMintPoolFromDB();
+        if (zwalletMain) {
+            zwalletMain->LoadMintPoolFromDB();
+        }
     }
 #endif
 
@@ -863,7 +865,7 @@ void ThreadImport(std::vector <boost::filesystem::path> vImportFiles) {
     }
 
 #ifdef ENABLE_WALLET
-    if (!GetBoolArg("-disablewallet", false)) {
+    if (!GetBoolArg("-disablewallet", false) && zwalletMain) {
         zwalletMain->SyncWithChain();
     }
 #endif
@@ -1704,7 +1706,7 @@ bool AppInit2(boost::thread_group &threadGroup, CScheduler &scheduler) {
                 // If the loaded chain has a wrong genesis, bail out immediately
                 // (we're likely using a testnet datadir, or the other way around).
                 if (!mapBlockIndex.empty() && mapBlockIndex.count(chainparams.GetConsensus().hashGenesisBlock) == 0) {
-                    LogPrintf("Genesis block hash %s not found.\n", 
+                    LogPrintf("Genesis block hash %s not found.\n",
                         chainparams.GetConsensus().hashGenesisBlock.ToString());
                     LogPrintf("mapBlockIndex contains %d blocks.\n", mapBlockIndex.size());
                     return InitError(_("Incorrect or no genesis block found. Wrong datadir for network?"));

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -122,7 +122,6 @@ BitcoinGUI::BitcoinGUI(const PlatformStyle *platformStyle, const NetworkStyle *n
     openRPCConsoleAction(0),
     openAction(0),
     showHelpMessageAction(0),
-    blankSigmaAction(0),
     zc2SigmaAction(0),
     znodeAction(0),
     trayIcon(0),
@@ -332,31 +331,21 @@ void BitcoinGUI::createActions()
 	historyAction->setShortcut(QKeySequence(Qt::ALT + key++));
 	tabGroup->addAction(historyAction);
 
-    blankSigmaAction = new QAction(platformStyle->SingleColorIcon(":/icons/sigma"), tr("Si&gma"), this);
-    blankSigmaAction->setStatusTip(tr("Anonymize your coins and perform private transfers using Sigma"));
-    blankSigmaAction->setToolTip(blankSigmaAction->statusTip());
-    blankSigmaAction->setCheckable(true);
-    blankSigmaAction->setShortcut(QKeySequence(Qt::ALT +  key++));
-    tabGroup->addAction(blankSigmaAction);
-    blankSigmaAction->setVisible(false);
-
     sigmaAction = new QAction(platformStyle->SingleColorIcon(":/icons/sigma"), tr("Si&gma"), this);
     sigmaAction->setStatusTip(tr("Anonymize your coins and perform private transfers using Sigma"));
     sigmaAction->setToolTip(sigmaAction->statusTip());
     sigmaAction->setCheckable(true);
     sigmaAction->setShortcut(QKeySequence(Qt::ALT +  key++));
     tabGroup->addAction(sigmaAction);
-    sigmaAction->setVisible(false);
+    sigmaAction->setVisible(true);
 
-
-
-        zc2SigmaAction = new QAction(platformStyle->SingleColorIcon(":/icons/zerocoin"), tr("&Remint"), this);
-        zc2SigmaAction->setStatusTip(tr("Show the list of public Zerocoins that could be reminted in Sigma"));
-        zc2SigmaAction->setToolTip(zc2SigmaAction->statusTip());
-        zc2SigmaAction->setCheckable(true);
-        zc2SigmaAction->setShortcut(QKeySequence(Qt::ALT +  key++));
-        tabGroup->addAction(zc2SigmaAction);
-        zc2SigmaAction->setVisible(false);
+    zc2SigmaAction = new QAction(platformStyle->SingleColorIcon(":/icons/zerocoin"), tr("&Remint"), this);
+    zc2SigmaAction->setStatusTip(tr("Show the list of public Zerocoins that could be reminted in Sigma"));
+    zc2SigmaAction->setToolTip(zc2SigmaAction->statusTip());
+    zc2SigmaAction->setCheckable(true);
+    zc2SigmaAction->setShortcut(QKeySequence(Qt::ALT +  key++));
+    tabGroup->addAction(zc2SigmaAction);
+    zc2SigmaAction->setVisible(false);
 
 #ifdef ENABLE_WALLET
     // These showNormalIfMinimized are needed because Send Coins and Receive Coins
@@ -405,7 +394,6 @@ void BitcoinGUI::createActions()
 	connect(historyAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
 	connect(historyAction, SIGNAL(triggered()), this, SLOT(gotoHistoryPage()));
 	connect(sigmaAction, SIGNAL(triggered()), this, SLOT(gotoSigmaPage()));
-    connect(blankSigmaAction, SIGNAL(triggered()), this, SLOT(gotoBlankSigmaPage()));
         connect(zc2SigmaAction, SIGNAL(triggered()), this, SLOT(gotoZc2SigmaPage()));
 
     if (exodusEnabled) {
@@ -548,7 +536,6 @@ void BitcoinGUI::createToolBars()
         toolbar->addAction(sendCoinsAction);
         toolbar->addAction(receiveCoinsAction);
         toolbar->addAction(historyAction);
-        toolbar->addAction(blankSigmaAction);
         toolbar->addAction(sigmaAction);
         toolbar->addAction(zc2SigmaAction);
         toolbar->addAction(znodeAction);
@@ -608,7 +595,6 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
             setTrayIconVisible(optionsModel->getHideTrayIcon());
         }
         checkZc2SigmaVisibility(clientModel->getNumBlocks());
-        checkSigmaPageVisibility();
     } else {
         // Disable possibility to show main window via action
         toggleHideAction->setEnabled(false);
@@ -662,7 +648,6 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     receiveCoinsAction->setEnabled(enabled);
     receiveCoinsMenuAction->setEnabled(enabled);
     historyAction->setEnabled(enabled);
-    blankSigmaAction->setEnabled(enabled);
     sigmaAction->setEnabled(enabled);
     znodeAction->setEnabled(enabled);
     encryptWalletAction->setEnabled(enabled);
@@ -851,11 +836,6 @@ void BitcoinGUI::gotoSignMessageTab(QString addr)
 void BitcoinGUI::gotoSigmaPage()
 {
     if (walletFrame) walletFrame->gotoSigmaPage();
-}
-
-void BitcoinGUI::gotoBlankSigmaPage()
-{
-    if (walletFrame) walletFrame->gotoBlankSigmaPage();
 }
 
 void BitcoinGUI::gotoZc2SigmaPage()
@@ -1366,16 +1346,6 @@ void BitcoinGUI::checkZc2SigmaVisibility(int numBlocks) {
 
         if(show)
             zc2SigmaAction->setVisible(true);
-    }
-}
-
-void BitcoinGUI::checkSigmaPageVisibility() {
-    if (pwalletMain->IsHDSeedAvailable()) {
-        blankSigmaAction->setVisible(false);
-        sigmaAction->setVisible(true);
-    } else {
-        blankSigmaAction->setVisible(true);
-        sigmaAction->setVisible(false);
     }
 }
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -122,6 +122,7 @@ BitcoinGUI::BitcoinGUI(const PlatformStyle *platformStyle, const NetworkStyle *n
     openRPCConsoleAction(0),
     openAction(0),
     showHelpMessageAction(0),
+    blankSigmaAction(0),
     zc2SigmaAction(0),
     znodeAction(0),
     trayIcon(0),
@@ -331,6 +332,14 @@ void BitcoinGUI::createActions()
 	historyAction->setShortcut(QKeySequence(Qt::ALT + key++));
 	tabGroup->addAction(historyAction);
 
+    blankSigmaAction = new QAction(platformStyle->SingleColorIcon(":/icons/sigma"), tr("Si&gma"), this);
+    blankSigmaAction->setStatusTip(tr("Anonymize your coins and perform private transfers using Sigma"));
+    blankSigmaAction->setToolTip(blankSigmaAction->statusTip());
+    blankSigmaAction->setCheckable(true);
+    blankSigmaAction->setShortcut(QKeySequence(Qt::ALT +  key++));
+    tabGroup->addAction(blankSigmaAction);
+    blankSigmaAction->setVisible(false);
+
     sigmaAction = new QAction(platformStyle->SingleColorIcon(":/icons/sigma"), tr("Si&gma"), this);
     sigmaAction->setStatusTip(tr("Anonymize your coins and perform private transfers using Sigma"));
     sigmaAction->setToolTip(sigmaAction->statusTip());
@@ -338,6 +347,8 @@ void BitcoinGUI::createActions()
     sigmaAction->setShortcut(QKeySequence(Qt::ALT +  key++));
     tabGroup->addAction(sigmaAction);
     sigmaAction->setVisible(false);
+
+
 
         zc2SigmaAction = new QAction(platformStyle->SingleColorIcon(":/icons/zerocoin"), tr("&Remint"), this);
         zc2SigmaAction->setStatusTip(tr("Show the list of public Zerocoins that could be reminted in Sigma"));
@@ -394,6 +405,7 @@ void BitcoinGUI::createActions()
 	connect(historyAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
 	connect(historyAction, SIGNAL(triggered()), this, SLOT(gotoHistoryPage()));
 	connect(sigmaAction, SIGNAL(triggered()), this, SLOT(gotoSigmaPage()));
+    connect(blankSigmaAction, SIGNAL(triggered()), this, SLOT(gotoBlankSigmaPage()));
         connect(zc2SigmaAction, SIGNAL(triggered()), this, SLOT(gotoZc2SigmaPage()));
 
     if (exodusEnabled) {
@@ -536,6 +548,7 @@ void BitcoinGUI::createToolBars()
         toolbar->addAction(sendCoinsAction);
         toolbar->addAction(receiveCoinsAction);
         toolbar->addAction(historyAction);
+        toolbar->addAction(blankSigmaAction);
         toolbar->addAction(sigmaAction);
         toolbar->addAction(zc2SigmaAction);
         toolbar->addAction(znodeAction);
@@ -649,6 +662,7 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     receiveCoinsAction->setEnabled(enabled);
     receiveCoinsMenuAction->setEnabled(enabled);
     historyAction->setEnabled(enabled);
+    blankSigmaAction->setEnabled(enabled);
     sigmaAction->setEnabled(enabled);
     znodeAction->setEnabled(enabled);
     encryptWalletAction->setEnabled(enabled);
@@ -837,6 +851,11 @@ void BitcoinGUI::gotoSignMessageTab(QString addr)
 void BitcoinGUI::gotoSigmaPage()
 {
     if (walletFrame) walletFrame->gotoSigmaPage();
+}
+
+void BitcoinGUI::gotoBlankSigmaPage()
+{
+    if (walletFrame) walletFrame->gotoBlankSigmaPage();
 }
 
 void BitcoinGUI::gotoZc2SigmaPage()
@@ -1352,7 +1371,11 @@ void BitcoinGUI::checkZc2SigmaVisibility(int numBlocks) {
 
 void BitcoinGUI::checkSigmaPageVisibility() {
     if (pwalletMain->IsHDSeedAvailable()) {
+        blankSigmaAction->setVisible(false);
         sigmaAction->setVisible(true);
+    } else {
+        blankSigmaAction->setVisible(true);
+        sigmaAction->setVisible(false);
     }
 }
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -331,12 +331,13 @@ void BitcoinGUI::createActions()
 	historyAction->setShortcut(QKeySequence(Qt::ALT + key++));
 	tabGroup->addAction(historyAction);
 
-	sigmaAction = new QAction(platformStyle->SingleColorIcon(":/icons/sigma"), tr("Si&gma"), this);
-	sigmaAction->setStatusTip(tr("Anonymize your coins and perform private transfers using Sigma"));
-	sigmaAction->setToolTip(sigmaAction->statusTip());
-	sigmaAction->setCheckable(true);
-	sigmaAction->setShortcut(QKeySequence(Qt::ALT +  key++));
-	tabGroup->addAction(sigmaAction);
+    sigmaAction = new QAction(platformStyle->SingleColorIcon(":/icons/sigma"), tr("Si&gma"), this);
+    sigmaAction->setStatusTip(tr("Anonymize your coins and perform private transfers using Sigma"));
+    sigmaAction->setToolTip(sigmaAction->statusTip());
+    sigmaAction->setCheckable(true);
+    sigmaAction->setShortcut(QKeySequence(Qt::ALT +  key++));
+    tabGroup->addAction(sigmaAction);
+    sigmaAction->setVisible(false);
 
         zc2SigmaAction = new QAction(platformStyle->SingleColorIcon(":/icons/zerocoin"), tr("&Remint"), this);
         zc2SigmaAction->setStatusTip(tr("Show the list of public Zerocoins that could be reminted in Sigma"));
@@ -594,6 +595,7 @@ void BitcoinGUI::setClientModel(ClientModel *clientModel)
             setTrayIconVisible(optionsModel->getHideTrayIcon());
         }
         checkZc2SigmaVisibility(clientModel->getNumBlocks());
+        checkSigmaPageVisibility();
     } else {
         // Disable possibility to show main window via action
         toggleHideAction->setEnabled(false);
@@ -1345,6 +1347,12 @@ void BitcoinGUI::checkZc2SigmaVisibility(int numBlocks) {
 
         if(show)
             zc2SigmaAction->setVisible(true);
+    }
+}
+
+void BitcoinGUI::checkSigmaPageVisibility() {
+    if (pwalletMain->IsHDSeedAvailable()) {
+        sigmaAction->setVisible(true);
     }
 }
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -116,6 +116,7 @@ private:
     QAction *openAction;
     QAction *showHelpMessageAction;
     QAction *sigmaAction;
+    QAction *blankSigmaAction;
     QAction *zc2SigmaAction;
     QAction *znodeAction;
 
@@ -213,7 +214,9 @@ private Q_SLOTS:
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
     void gotoSendCoinsPage(QString addr = "");
-     /** Switch to sigma page */
+    /** Switch to blank sigma page */
+    void gotoBlankSigmaPage();
+    /** Switch to sigma page */
     void gotoSigmaPage();
     /** Switch to ZC->sigma page */
     void gotoZc2SigmaPage();

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -153,6 +153,9 @@ private:
     /** Updates Zc2SigmaPage visibility */
     void checkZc2SigmaVisibility(int numBlocks);
 
+    /** Update sigmaPage visibility */
+    void checkSigmaPageVisibility();
+
 Q_SIGNALS:
     /** Signal raised when a URI was entered or dragged to the GUI */
     void receivedURI(const QString &uri);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -116,7 +116,6 @@ private:
     QAction *openAction;
     QAction *showHelpMessageAction;
     QAction *sigmaAction;
-    QAction *blankSigmaAction;
     QAction *zc2SigmaAction;
     QAction *znodeAction;
 
@@ -153,9 +152,6 @@ private:
 
     /** Updates Zc2SigmaPage visibility */
     void checkZc2SigmaVisibility(int numBlocks);
-
-    /** Update sigmaPage visibility */
-    void checkSigmaPageVisibility();
 
 Q_SIGNALS:
     /** Signal raised when a URI was entered or dragged to the GUI */
@@ -214,8 +210,6 @@ private Q_SLOTS:
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
     void gotoSendCoinsPage(QString addr = "");
-    /** Switch to blank sigma page */
-    void gotoBlankSigmaPage();
     /** Switch to sigma page */
     void gotoSigmaPage();
     /** Switch to ZC->sigma page */

--- a/src/qt/forms/blanksigmadialog.ui
+++ b/src/qt/forms/blanksigmadialog.ui
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>BlankSigmaDialog</class>
+ <widget class="QWidget" name="BlankSigmaDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>835</width>
+    <height>593</height>
+   </rect>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout_1">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_1">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>We have detected that your wallet does not use a HD seed. A HD seed allows you to restore all your private keys and also Sigma mints even when restoring from an old backup.
+
+To have Sigma private transactions functionality, a HD wallet is required. We highly recommend that you create a new wallet and move your funds over to the new wallet version or use the dumpwallet in conjunction with importprivkey commands to move the keys to the new wallet.
+</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/sigmadialog.cpp
+++ b/src/qt/sigmadialog.cpp
@@ -1,5 +1,6 @@
 #include "sigmadialog.h"
 #include "ui_sigmadialog.h"
+#include "ui_blanksigmadialog.h"
 
 #include "bitcoinunits.h"
 #include "guiutil.h"
@@ -26,6 +27,18 @@
 #include <unordered_map>
 
 #define SEND_CONFIRM_DELAY   3
+
+BlankSigmaDialog::BlankSigmaDialog() :
+    ui(new Ui::BlankSigmaDialog)
+{
+    ui->setupUi(this);
+    setWindowTitle(tr("sigma"));
+}
+
+BlankSigmaDialog::~BlankSigmaDialog()
+{
+    delete ui;
+}
 
 SigmaDialog::SigmaDialog(const PlatformStyle *platformStyle, QWidget *parent) :
     QDialog(parent),

--- a/src/qt/sigmadialog.h
+++ b/src/qt/sigmadialog.h
@@ -12,7 +12,20 @@
 
 namespace Ui {
     class SigmaDialog;
+    class BlankSigmaDialog;
 }
+
+class BlankSigmaDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    BlankSigmaDialog();
+    ~BlankSigmaDialog();
+
+private:
+    Ui::BlankSigmaDialog *ui;
+};
 
 class SigmaDialog : public QDialog
 {

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -190,6 +190,13 @@ void WalletFrame::gotoSigmaPage()
         i.value()->gotoSigmaPage();
 }
 
+void WalletFrame::gotoBlankSigmaPage()
+{
+    QMap<QString, WalletView*>::const_iterator i;
+    for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
+        i.value()->gotoBlankSigmaPage();
+}
+
 void WalletFrame::gotoZc2SigmaPage()
 {
     QMap<QString, WalletView*>::const_iterator i;

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -190,13 +190,6 @@ void WalletFrame::gotoSigmaPage()
         i.value()->gotoSigmaPage();
 }
 
-void WalletFrame::gotoBlankSigmaPage()
-{
-    QMap<QString, WalletView*>::const_iterator i;
-    for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
-        i.value()->gotoBlankSigmaPage();
-}
-
 void WalletFrame::gotoZc2SigmaPage()
 {
     QMap<QString, WalletView*>::const_iterator i;

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -71,6 +71,8 @@ public Q_SLOTS:
     void gotoSendCoinsPage(QString addr = "");
     /** Switch to zerocoin page */
     void gotoZerocoinPage();
+    /** Switch to blank sigma page */
+    void gotoBlankSigmaPage();
     /** Switch to sigma page */
     void gotoSigmaPage();
     /** Switch to sigma page */

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -71,8 +71,6 @@ public Q_SLOTS:
     void gotoSendCoinsPage(QString addr = "");
     /** Switch to zerocoin page */
     void gotoZerocoinPage();
-    /** Switch to blank sigma page */
-    void gotoBlankSigmaPage();
     /** Switch to sigma page */
     void gotoSigmaPage();
     /** Switch to sigma page */

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -566,10 +566,14 @@ static void NotifyZerocoinChanged(WalletModel *walletmodel, CWallet *wallet, con
                               Q_ARG(QString, QString::fromStdString(pubCoin)),
                               Q_ARG(QString, QString::fromStdString(isUsed)),
                               Q_ARG(int, status));
-    QMetaObject::invokeMethod(walletmodel, "updateSigmaCoins", Qt::QueuedConnection,
+
+    // disable sigma
+    if (pwalletMain->IsHDSeedAvailable()) {
+        QMetaObject::invokeMethod(walletmodel, "updateSigmaCoins", Qt::QueuedConnection,
                               Q_ARG(QString, QString::fromStdString(pubCoin)),
                               Q_ARG(QString, QString::fromStdString(isUsed)),
                               Q_ARG(int, status));
+    }
 }
 
 static void NotifyTransactionChanged(WalletModel *walletmodel, CWallet *wallet, const uint256 &hash, ChangeType status)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -139,7 +139,10 @@ void WalletModel::pollBalanceChanged()
             transactionTableModel->updateConfirmations();
 
         // check sigma
-        checkSigmaAmount(false);
+        // support only hd
+        if (pwalletMain->IsHDSeedAvailable()) {
+            checkSigmaAmount(false);
+        }
     }
 }
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -397,7 +397,11 @@ void WalletView::gotoSigmaPage()
 
 void WalletView::gotoZc2SigmaPage()
 {
-    setCurrentWidget(zc2SigmaPage);
+    if (pwalletMain->IsHDSeedAvailable()) {
+        setCurrentWidget(zc2SigmaPage);
+    } else {
+        setCurrentWidget(sigmaPage);
+    }
 }
 
 void WalletView::gotoToolboxPage()

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -67,7 +67,9 @@ WalletView::WalletView(const PlatformStyle *platformStyle, QWidget *parent):
     usedSendingAddressesPage = new AddressBookPage(platformStyle, AddressBookPage::ForEditing, AddressBookPage::SendingTab, this);
     usedReceivingAddressesPage = new AddressBookPage(platformStyle, AddressBookPage::ForEditing, AddressBookPage::ReceivingTab, this);
     zerocoinPage = new ZerocoinPage(platformStyle, ZerocoinPage::ForEditing, this);
-    sigmaPage = new QWidget(this);
+    if (pwalletMain->IsHDSeedAvailable()) {
+        sigmaPage = new QWidget(this);
+    }
     zc2SigmaPage = new Zc2SigmaPage(platformStyle, this);
     sendCoinsPage = new QWidget(this);
     toolboxPage = new QWidget(this);
@@ -76,7 +78,9 @@ WalletView::WalletView(const PlatformStyle *platformStyle, QWidget *parent):
     setupTransactionPage();
     setupSendCoinPage();
     setupToolboxPage();
-    setupSigmaPage();
+    if (pwalletMain->IsHDSeedAvailable()) {
+        setupSigmaPage();
+    }
 
     addWidget(overviewPage);
     addWidget(exoAssetsPage);
@@ -84,7 +88,9 @@ WalletView::WalletView(const PlatformStyle *platformStyle, QWidget *parent):
     addWidget(receiveCoinsPage);
     addWidget(sendCoinsPage);
     addWidget(zerocoinPage);
-    addWidget(sigmaPage);
+    if (pwalletMain->IsHDSeedAvailable()) {
+        addWidget(sigmaPage);
+    }
     addWidget(zc2SigmaPage);
     addWidget(toolboxPage);
     addWidget(znodeListPage);
@@ -235,7 +241,9 @@ void WalletView::setClientModel(ClientModel *clientModel)
     sendZcoinView->setClientModel(clientModel);
     znodeListPage->setClientModel(clientModel);
     exoAssetsPage->setClientModel(clientModel);
-    sigmaView->setClientModel(clientModel);
+    if (pwalletMain->IsHDSeedAvailable()) {
+        sigmaView->setClientModel(clientModel);
+    }
     zc2SigmaPage->setClientModel(clientModel);
 
     if (exodusTransactionsView) {
@@ -256,7 +264,9 @@ void WalletView::setWalletModel(WalletModel *walletModel)
     overviewPage->setWalletModel(walletModel);
     receiveCoinsPage->setModel(walletModel);
     zerocoinPage->setModel(walletModel->getAddressTableModel());
-    sigmaView->setWalletModel(walletModel);
+    if (pwalletMain->IsHDSeedAvailable()) {
+        sigmaView->setWalletModel(walletModel);
+    }
     zc2SigmaPage->createModel();
     usedReceivingAddressesPage->setModel(walletModel->getAddressTableModel());
     usedSendingAddressesPage->setModel(walletModel->getAddressTableModel());
@@ -381,7 +391,9 @@ void WalletView::gotoZerocoinPage()
 
 void WalletView::gotoSigmaPage()
 {
-    setCurrentWidget(sigmaPage);
+    if (pwalletMain->IsHDSeedAvailable()) {
+        setCurrentWidget(sigmaPage);
+    }
 }
 
 void WalletView::gotoZc2SigmaPage()

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -68,11 +68,7 @@ WalletView::WalletView(const PlatformStyle *platformStyle, QWidget *parent):
     usedSendingAddressesPage = new AddressBookPage(platformStyle, AddressBookPage::ForEditing, AddressBookPage::SendingTab, this);
     usedReceivingAddressesPage = new AddressBookPage(platformStyle, AddressBookPage::ForEditing, AddressBookPage::ReceivingTab, this);
     zerocoinPage = new ZerocoinPage(platformStyle, ZerocoinPage::ForEditing, this);
-    if (pwalletMain->IsHDSeedAvailable()) {
-        sigmaPage = new QWidget(this);
-    } else {
-        blankSigmaPage = new QWidget(this);
-    }
+    sigmaPage = new QWidget(this);
     zc2SigmaPage = new Zc2SigmaPage(platformStyle, this);
     sendCoinsPage = new QWidget(this);
     toolboxPage = new QWidget(this);
@@ -81,11 +77,7 @@ WalletView::WalletView(const PlatformStyle *platformStyle, QWidget *parent):
     setupTransactionPage();
     setupSendCoinPage();
     setupToolboxPage();
-    if (pwalletMain->IsHDSeedAvailable()) {
-        setupSigmaPage();
-    } else {
-        setupBlankSigmaPage();
-    }
+    setupSigmaPage();
 
     addWidget(overviewPage);
     addWidget(exoAssetsPage);
@@ -93,11 +85,7 @@ WalletView::WalletView(const PlatformStyle *platformStyle, QWidget *parent):
     addWidget(receiveCoinsPage);
     addWidget(sendCoinsPage);
     addWidget(zerocoinPage);
-    if (pwalletMain->IsHDSeedAvailable()) {
-        addWidget(sigmaPage);
-    } else {
-        addWidget(blankSigmaPage);
-    }
+    addWidget(sigmaPage);
     addWidget(zc2SigmaPage);
     addWidget(toolboxPage);
     addWidget(znodeListPage);
@@ -190,25 +178,21 @@ void WalletView::setupSendCoinPage()
     sendCoinsPage->setLayout(pageLayout);
 }
 
-void WalletView::setupBlankSigmaPage()
-{
-    blankSigmaView = new BlankSigmaDialog();
-
-    // Set layout for Sigma page
-    auto pageLayout = new QVBoxLayout();
-    pageLayout->addWidget(blankSigmaView);
-    blankSigmaPage->setLayout(pageLayout);
-}
-
 void WalletView::setupSigmaPage()
 {
-    sigmaView = new SigmaDialog(platformStyle);
-    connect(sigmaView, SIGNAL(message(QString, QString, unsigned int)), this, SIGNAL(message(QString, QString, unsigned int)));
-
     // Set layout for Sigma page
     auto pageLayout = new QVBoxLayout();
-    pageLayout->addWidget(sigmaView);
-    sigmaPage->setLayout(pageLayout);
+
+    if (pwalletMain->IsHDSeedAvailable()) {
+        sigmaView = new SigmaDialog(platformStyle);
+        connect(sigmaView, SIGNAL(message(QString, QString, unsigned int)), this, SIGNAL(message(QString, QString, unsigned int)));
+        pageLayout->addWidget(sigmaView);
+        sigmaPage->setLayout(pageLayout);
+    } else {
+        blankSigmaView = new BlankSigmaDialog();
+        pageLayout->addWidget(blankSigmaView);
+        sigmaPage->setLayout(pageLayout);
+    }
 }
 
 void WalletView::setupToolboxPage()
@@ -408,16 +392,7 @@ void WalletView::gotoZerocoinPage()
 
 void WalletView::gotoSigmaPage()
 {
-    if (pwalletMain->IsHDSeedAvailable()) {
-        setCurrentWidget(sigmaPage);
-    }
-}
-
-void WalletView::gotoBlankSigmaPage()
-{
-    if (!pwalletMain->IsHDSeedAvailable()) {
-        setCurrentWidget(blankSigmaPage);
-    }
+    setCurrentWidget(sigmaPage);
 }
 
 void WalletView::gotoZc2SigmaPage()

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -53,6 +53,7 @@ WalletView::WalletView(const PlatformStyle *platformStyle, QWidget *parent):
     overviewPage(0),
     sendExodusView(0),
     sigmaView(0),
+    blankSigmaView(0),
     zc2SigmaPage(0),
     exodusTransactionsView(0),
     zcoinTransactionsView(0),
@@ -69,6 +70,8 @@ WalletView::WalletView(const PlatformStyle *platformStyle, QWidget *parent):
     zerocoinPage = new ZerocoinPage(platformStyle, ZerocoinPage::ForEditing, this);
     if (pwalletMain->IsHDSeedAvailable()) {
         sigmaPage = new QWidget(this);
+    } else {
+        blankSigmaPage = new QWidget(this);
     }
     zc2SigmaPage = new Zc2SigmaPage(platformStyle, this);
     sendCoinsPage = new QWidget(this);
@@ -80,6 +83,8 @@ WalletView::WalletView(const PlatformStyle *platformStyle, QWidget *parent):
     setupToolboxPage();
     if (pwalletMain->IsHDSeedAvailable()) {
         setupSigmaPage();
+    } else {
+        setupBlankSigmaPage();
     }
 
     addWidget(overviewPage);
@@ -90,6 +95,8 @@ WalletView::WalletView(const PlatformStyle *platformStyle, QWidget *parent):
     addWidget(zerocoinPage);
     if (pwalletMain->IsHDSeedAvailable()) {
         addWidget(sigmaPage);
+    } else {
+        addWidget(blankSigmaPage);
     }
     addWidget(zc2SigmaPage);
     addWidget(toolboxPage);
@@ -181,6 +188,16 @@ void WalletView::setupSendCoinPage()
     }
 
     sendCoinsPage->setLayout(pageLayout);
+}
+
+void WalletView::setupBlankSigmaPage()
+{
+    blankSigmaView = new BlankSigmaDialog();
+
+    // Set layout for Sigma page
+    auto pageLayout = new QVBoxLayout();
+    pageLayout->addWidget(blankSigmaView);
+    blankSigmaPage->setLayout(pageLayout);
 }
 
 void WalletView::setupSigmaPage()
@@ -393,6 +410,13 @@ void WalletView::gotoSigmaPage()
 {
     if (pwalletMain->IsHDSeedAvailable()) {
         setCurrentWidget(sigmaPage);
+    }
+}
+
+void WalletView::gotoBlankSigmaPage()
+{
+    if (!pwalletMain->IsHDSeedAvailable()) {
+        setCurrentWidget(blankSigmaPage);
     }
 }
 

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -72,7 +72,6 @@ private:
     void setupTransactionPage();
     void setupSendCoinPage();
     void setupToolboxPage();
-    void setupBlankSigmaPage();
     void setupSigmaPage();
 
 private:
@@ -95,9 +94,8 @@ private:
     MetaDExCancelDialog *cancelTab;
     ZerocoinPage *zerocoinPage;
     SigmaDialog *sigmaView;
-    QWidget *sigmaPage;
     BlankSigmaDialog *blankSigmaView;
-    QWidget *blankSigmaPage;
+    QWidget *sigmaPage;
     Zc2SigmaPage *zc2SigmaPage;
     TransactionView *zcoinTransactionList;
     TXHistoryDialog *exodusTransactionsView;
@@ -133,8 +131,6 @@ public Q_SLOTS:
     void gotoSendCoinsPage(QString addr = "");
     /** Switch to zerocoin page */
     void gotoZerocoinPage();
-    /** Switch to blank sigma page */
-    void gotoBlankSigmaPage();
     /** Switch to sigma page */
     void gotoSigmaPage();
     /** Switch to ZC to Sigma page */

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -72,6 +72,7 @@ private:
     void setupTransactionPage();
     void setupSendCoinPage();
     void setupToolboxPage();
+    void setupBlankSigmaPage();
     void setupSigmaPage();
 
 private:
@@ -95,6 +96,8 @@ private:
     ZerocoinPage *zerocoinPage;
     SigmaDialog *sigmaView;
     QWidget *sigmaPage;
+    BlankSigmaDialog *blankSigmaView;
+    QWidget *blankSigmaPage;
     Zc2SigmaPage *zc2SigmaPage;
     TransactionView *zcoinTransactionList;
     TXHistoryDialog *exodusTransactionsView;
@@ -130,6 +133,8 @@ public Q_SLOTS:
     void gotoSendCoinsPage(QString addr = "");
     /** Switch to zerocoin page */
     void gotoZerocoinPage();
+    /** Switch to blank sigma page */
+    void gotoBlankSigmaPage();
     /** Switch to sigma page */
     void gotoSigmaPage();
     /** Switch to ZC to Sigma page */

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -204,7 +204,7 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn, const bool& fF
             return false;
         vMasterKey = vMasterKeyIn;
         fDecryptionThoroughlyChecked = true;
-        if(!fFirstUnlock){
+        if(!fFirstUnlock && zwalletMain){
             uint160 hashSeedMaster = pwalletMain->GetHDChain().masterKeyID;
             zwalletMain->SetupWallet(hashSeedMaster, false);
             zwalletMain->SyncWithChain();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -75,6 +75,16 @@ bool EnsureWalletIsAvailable(bool avoidException)
     return true;
 }
 
+bool EnsureHDSeedIsAvailable(bool avoidException = false) {
+    if (!pwalletMain || !pwalletMain->IsHDSeedAvailable()) {
+        if (!avoidException) {
+            throw JSONRPCError(RPC_WALLET_ERROR, "sigma mint/spend is not allow for legacy wallet");
+        }
+        return false;
+    }
+    return true;
+}
+
 void EnsureWalletIsUnlocked()
 {
     if (pwalletMain->IsLocked())
@@ -2705,6 +2715,7 @@ UniValue listunspentmintzerocoins(const UniValue &params, bool fHelp) {
 }
 
 UniValue listunspentsigmamints(const UniValue &params, bool fHelp) {
+    EnsureHDSeedIsAvailable(fHelp);
     if (fHelp || params.size() > 2)
         throw runtime_error(
                 "listunspentsigmamints [minconf=1] [maxconf=9999999] \n"
@@ -2765,6 +2776,8 @@ UniValue mint(const UniValue& params, bool fHelp)
     if (!EnsureWalletIsAvailable(fHelp)) {
         return NullUniValue;
     }
+
+    EnsureHDSeedIsAvailable(fHelp);
 
     if (fHelp || params.size() != 1)
         throw std::runtime_error(
@@ -3226,6 +3239,8 @@ UniValue spendmanyzerocoin(const UniValue& params, bool fHelp) {
 
 UniValue spendmany(const UniValue& params, bool fHelp) {
 
+    EnsureHDSeedIsAvailable(fHelp);
+
     if (fHelp || params.size() < 2 || params.size() > 5)
         throw std::runtime_error(
                 "spendmany \"fromaccount\" {\"address\":amount,...} ( minconf \"comment\" [\"address\",...] )\n"
@@ -3359,6 +3374,8 @@ UniValue resetmintzerocoin(const UniValue& params, bool fHelp) {
 }
 
 UniValue resetsigmamint(const UniValue& params, bool fHelp) {
+
+    EnsureHDSeedIsAvailable(fHelp);
     if (fHelp || params.size() != 0)
         throw runtime_error(
                 "resetsigmamint"
@@ -3418,6 +3435,9 @@ UniValue listmintzerocoins(const UniValue& params, bool fHelp) {
 }
 
 UniValue listsigmamints(const UniValue& params, bool fHelp) {
+
+    EnsureHDSeedIsAvailable(fHelp);
+
     if (fHelp || params.size() > 1)
         throw runtime_error(
                 "listsigmamints <all>(false/true)\n"
@@ -3495,6 +3515,9 @@ UniValue listpubcoins(const UniValue& params, bool fHelp) {
 }
 
 UniValue listsigmapubcoins(const UniValue& params, bool fHelp) {
+
+    EnsureHDSeedIsAvailable(fHelp);
+
     std::string help_message =
         "listsigmapubcoins <all>(0.05/0.1/0.5/1/10/25/100)\n"
             "\nArguments:\n"
@@ -3609,6 +3632,9 @@ UniValue setmintzerocoinstatus(const UniValue& params, bool fHelp) {
 }
 
 UniValue setsigmamintstatus(const UniValue& params, bool fHelp) {
+
+    EnsureHDSeedIsAvailable(fHelp);
+
     if (fHelp || params.size() != 2)
         throw runtime_error(
                 "setsigmamintstatus \"coinserial\" <isused>(true/false)\n"
@@ -3684,6 +3710,9 @@ UniValue setsigmamintstatus(const UniValue& params, bool fHelp) {
 }
 
 UniValue listsigmaspends(const UniValue &params, bool fHelp) {
+
+    EnsureHDSeedIsAvailable(fHelp);
+
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
                 "listsigmaspends\n"
@@ -3866,6 +3895,10 @@ UniValue listspendzerocoins(const UniValue &params, bool fHelp) {
 }
 
 UniValue remintzerocointosigma(const UniValue &params, bool fHelp) {
+
+    // Currently sigma support only HDMint
+    EnsureHDSeedIsAvailable(fHelp);
+
     if (fHelp || params.size() != 1)
         throw runtime_error(
             "remintzerocointosigma <denomination>(1,10,25,50,100)\n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -78,7 +78,7 @@ bool EnsureWalletIsAvailable(bool avoidException)
 bool EnsureHDSeedIsAvailable(bool avoidException = false) {
     if (!pwalletMain || !pwalletMain->IsHDSeedAvailable()) {
         if (!avoidException) {
-            throw JSONRPCError(RPC_WALLET_ERROR, "sigma mint/spend is not allow for legacy wallet");
+            throw JSONRPCError(RPC_WALLET_ERROR, "sigma mint/spend is not allowed for legacy wallet");
         }
         return false;
     }

--- a/src/wallet/sigmaspendbuilder.cpp
+++ b/src/wallet/sigmaspendbuilder.cpp
@@ -161,7 +161,9 @@ CAmount SigmaSpendBuilder::GetChanges(std::vector<CTxOut>& outputs, CAmount amou
 
         sigma::PrivateCoin newCoin(params, denomination, ZEROCOIN_TX_VERSION_3);
         hdMint.SetNull();
-        zwalletMain->GenerateMint(denomination, newCoin, hdMint);
+        if (zwalletMain) {
+            zwalletMain->GenerateMint(denomination, newCoin, hdMint);
+        }
         auto& pubCoin = newCoin.getPublicCoin();
 
         if (!pubCoin.validate()) {

--- a/src/wallet/txbuilder.cpp
+++ b/src/wallet/txbuilder.cpp
@@ -103,10 +103,15 @@ CWalletTx TxBuilder::Build(const std::vector<CRecipient>& recipients, CAmount& f
     assert(tx.nLockTime < LOCKTIME_THRESHOLD);
 
     // Start with no fee and loop until there is enough fee;
-    uint32_t nCountNextUse = zwalletMain->GetCount();
+    uint32_t nCountNextUse;
+    if (zwalletMain) {
+        nCountNextUse = zwalletMain->GetCount();
+    }
     for (fee = payTxFee.GetFeePerK();;) {
         // In case of not enough fee, reset mint seed counter
-        zwalletMain->SetCount(nCountNextUse);
+        if (zwalletMain) {
+            zwalletMain->SetCount(nCountNextUse);
+        }
         CAmount required = spend;
 
         tx.vin.clear();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -767,6 +767,8 @@ public:
      */
     void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed=true, const CCoinControl *coinControl = NULL, bool fIncludeZeroValue=false, AvailableCoinsType nCoinType=ALL_COINS, bool fUseInstantSend = false) const;
 
+    bool IsHDSeedAvailable() { return !hdChain.masterKeyID.IsNull(); }
+
     /**
      * Shuffle and select coins until nTargetValue is reached while avoiding
      * small change; This method is stochastic for some inputs and upon


### PR DESCRIPTION
- disable rpc
- disable zwallet
- disble GUI and show message below on sigma and remint tab.

```
We have detected that your wallet does not use a HD seed. A HD seed allows you to restore all your private keys and also Sigma mints even when restoring from an old backup.

To have Sigma private transactions functionality, a HD wallet is required. We highly recommend that you create a new wallet and move your funds over to the new wallet version or use the dumpwallet in conjunction with importprivkey commands to move the keys to the new wallet.
```

GUI when use nonhd wallet are uploaded to link below.

https://trello.com/c/6avQbIke/197-ask-users-to-upgrade-old-wallet-to-hd-wallet