### PR TITLE
Dump/Import wallet RPC Updates

### DIFF
--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -64,6 +64,33 @@ bool CHDMintWallet::SetupWallet(const uint160& hashSeedMaster, bool fResetCount)
     return true;
 }
 
+// Regenerate mintPool entry from given values
+void CHDMintWallet::RegenerateMintPoolEntry(const uint160& mintHashSeedMaster, CKeyID& seedId, const int32_t& nCount)
+{
+    CWalletDB walletdb(strWalletFile);
+    //Is locked
+    if (pwalletMain->IsLocked())
+        return;
+
+    uint512 seedZerocoin;
+    if(!CreateZerocoinSeed(seedZerocoin, nCount, seedId, false))
+        return;
+
+    GroupElement commitmentValue;
+    sigma::PrivateCoin coin(sigma::Params::get_default(), sigma::CoinDenomination::SIGMA_DENOM_1);
+    if(!SeedToZerocoin(seedZerocoin, commitmentValue, coin))
+        return;
+
+    uint256 hashPubcoin = primitives::GetPubCoinValueHash(commitmentValue);
+
+    MintPoolEntry mintPoolEntry(mintHashSeedMaster, seedId, nCount);
+    mintPool.Add(make_pair(hashPubcoin, mintPoolEntry));
+    CWalletDB(strWalletFile).WritePubcoin(primitives::GetSerialHash(coin.getSerialNumber()), commitmentValue);
+    CWalletDB(strWalletFile).WriteMintPoolPair(hashPubcoin, mintPoolEntry);
+    LogPrintf("%s : hashSeedMaster=%s hashPubcoin=%s count=%d\n", __func__, hashSeedMaster.GetHex(), hashPubcoin.GetHex(), nCount);
+
+}
+
 // Add up to nIndex + 20 new mints to the mint pool (defaults to adding 20 mints if no param passed)
 void CHDMintWallet::GenerateMintPool(int32_t nIndex)
 {
@@ -102,7 +129,7 @@ void CHDMintWallet::GenerateMintPool(int32_t nIndex)
         mintPool.Add(make_pair(hashPubcoin, mintPoolEntry));
         CWalletDB(strWalletFile).WritePubcoin(primitives::GetSerialHash(coin.getSerialNumber()), commitmentValue);
         CWalletDB(strWalletFile).WriteMintPoolPair(hashPubcoin, mintPoolEntry);
-        LogPrintf("%s : %s count=%d\n", __func__, hashPubcoin.GetHex(), nLastCount);
+        LogPrintf("%s : hashSeedMaster=%s hashPubcoin=%s count=%d\n", __func__, hashSeedMaster.GetHex(), hashPubcoin.GetHex(), nLastCount);
     }
 
     // Update local + DB entries for count last generated

--- a/src/hdmint/wallet.h
+++ b/src/hdmint/wallet.h
@@ -36,6 +36,7 @@ public:
     bool RegenerateMint(const CHDMint& dMint, CSigmaEntry& zerocoin);
     bool IsSerialInBlockchain(const uint256& hashSerial, int& nHeightTx, uint256& txidSpend, CTransaction& tx);
     bool TxOutToPublicCoin(const CTxOut& txout, sigma::PublicCoin& pubCoin, CValidationState& state);
+    void RegenerateMintPoolEntry(const uint160& mintHashSeedMaster, CKeyID& seedId, const int32_t& nCount);
     void GenerateMintPool(int32_t nIndex = 0);
     bool SetMintSeedSeen(std::pair<uint256,MintPoolEntry> mintPoolEntryPair, const int& nHeight, const uint256& txid, const sigma::CoinDenomination& denom);
     bool SeedToZerocoin(const uint512& seedZerocoin, GroupElement& bnValue, sigma::PrivateCoin& coin);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -444,6 +444,8 @@ UniValue importwallet(const UniValue& params, bool fHelp)
 
     bool fGood = true;
 
+    bool fMintUpdate = false;
+
     int64_t nFilesize = std::max((int64_t)1, (int64_t)file.tellg());
     file.seekg(0, file.beg);
 
@@ -473,6 +475,10 @@ UniValue importwallet(const UniValue& params, bool fHelp)
         int64_t nTime = DecodeDumpTime(vstr[1]);
         std::string strLabel;
         bool fLabel = true;
+        // CKeyMetadata
+        bool fHd = false;
+        std::string hdKeypath;
+        CKeyID hdMasterKeyID;
         for (unsigned int nStr = 2; nStr < vstr.size(); nStr++) {
             if (boost::algorithm::starts_with(vstr[nStr], "#"))
                 break;
@@ -484,13 +490,36 @@ UniValue importwallet(const UniValue& params, bool fHelp)
                 strLabel = DecodeDumpString(vstr[nStr].substr(6));
                 fLabel = true;
             }
+            if(boost::algorithm::starts_with(vstr[nStr], "hdKeypath=")){
+                hdKeypath = vstr[nStr].substr(10);
+                fHd = true;
+            }
+            if(boost::algorithm::starts_with(vstr[nStr], "hdMasterKeyID=")){
+                hdMasterKeyID.SetHex(vstr[nStr].substr(14));
+            }
         }
         LogPrintf("Importing %s...\n", CBitcoinAddress(keyid).ToString());
+
+        // Add entry to mapKeyMetadata (Need to populate KeyMetadata before for it to be written to DB in the following call)
+        pwalletMain->mapKeyMetadata[keyid].nCreateTime = nTime;
+        if(fHd){
+            pwalletMain->mapKeyMetadata[keyid].hdKeypath = hdKeypath;
+            pwalletMain->mapKeyMetadata[keyid].hdMasterKeyID = hdMasterKeyID;
+            pwalletMain->mapKeyMetadata[keyid].ParseComponents();
+        }
+
         if (!pwalletMain->AddKeyPubKey(key, pubkey)) {
             fGood = false;
             continue;
         }
-        pwalletMain->mapKeyMetadata[keyid].nCreateTime = nTime;
+
+        if(fHd){
+            // If change component in HD path is 2, this is a mint seed key. Add to mintpool. (Have to call after key addition)
+            if(pwalletMain->mapKeyMetadata[keyid].nChange==2){
+                zwalletMain->RegenerateMintPoolEntry(hdMasterKeyID, keyid, pwalletMain->mapKeyMetadata[keyid].nChild);
+                fMintUpdate = true;
+            }
+        }
         if (fLabel)
             pwalletMain->SetAddressBook(keyid, strLabel, "receive");
         nTimeBegin = std::min(nTimeBegin, nTime);
@@ -508,6 +537,9 @@ UniValue importwallet(const UniValue& params, bool fHelp)
     LogPrintf("Rescanning last %i blocks\n", chainActive.Height() - pindex->nHeight + 1);
     pwalletMain->ScanForWalletTransactions(pindex);
     pwalletMain->MarkDirty();
+
+    if(fMintUpdate)
+        zwalletMain->SyncWithChain();
 
     if (!fGood)
         throw JSONRPCError(RPC_WALLET_ERROR, "Error adding some keys to wallet");
@@ -599,7 +631,6 @@ UniValue dumpprivkey_zcoin(const UniValue& params, bool fHelp)
     return dumpprivkey(dumpParams, false);
 }
 
-//This method intentionally left unchanged.
 UniValue dumpwallet(const UniValue& params, bool fHelp)
 {
     if (!EnsureWalletIsAvailable(fHelp))
@@ -679,7 +710,13 @@ UniValue dumpwallet(const UniValue& params, bool fHelp)
             } else {
                 file << "change=1";
             }
-            file << strprintf(" # addr=%s%s\n", strAddr, (pwalletMain->mapKeyMetadata[keyid].hdKeypath.size() > 0 ? " hdkeypath="+pwalletMain->mapKeyMetadata[keyid].hdKeypath : ""));
+            if(pwalletMain->mapKeyMetadata.find(keyid) != pwalletMain->mapKeyMetadata.end()){
+                if(pwalletMain->mapKeyMetadata[keyid].nVersion >= CKeyMetadata::VERSION_WITH_HDDATA){
+                    file << strprintf(" hdKeypath=%s", pwalletMain->mapKeyMetadata[keyid].hdKeypath);
+                    file << strprintf(" hdMasterKeyID=%s", pwalletMain->mapKeyMetadata[keyid].hdMasterKeyID.ToString());
+                }
+            }
+            file << strprintf(" # addr=%s\n", strAddr);
         }
     }
     file << "\n";

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -138,6 +138,7 @@ CPubKey CWallet::GenerateNewKey(uint32_t nChange) {
     // Create new metadata
     int64_t nCreationTime = GetTime();
     CKeyMetadata metadata(nCreationTime);
+    metadata.nChange = nChange;
 
     boost::optional<bool> regTest = GetOptBoolArg("-regtest")
     , testNet = GetOptBoolArg("-testnet");

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -25,6 +25,10 @@
 #include <vector>
 #include "libzerocoin/Zerocoin.h"
 
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/lexical_cast.hpp>
+
 static const bool DEFAULT_FLUSHWALLET = true;
 
 class CAccount;
@@ -102,6 +106,7 @@ public:
     int nVersion;
     int64_t nCreateTime; // 0 means unknown
     std::string hdKeypath; //optional HD/bip32 keypath
+    int64_t nChange; // HD/bip32 keypath change counter
     int64_t nChild; // HD/bip32 keypath child counter
     CKeyID hdMasterKeyID; //id of the HD masterkey used to derive this key
 
@@ -113,6 +118,16 @@ public:
     {
         SetNull();
         nCreateTime = nCreateTime_;
+    }
+
+    bool ParseComponents(){
+        std::vector<std::string> nComponents;
+        if(hdKeypath=="m")
+            return false;
+        boost::split(nComponents, hdKeypath, boost::is_any_of("/"), boost::token_compress_on);
+        nChange = boost::lexical_cast<int64_t>(nComponents[4]);
+        nChild = boost::lexical_cast<int64_t>(nComponents[5]);
+        return true;
     }
 
     ADD_SERIALIZE_METHODS;
@@ -135,6 +150,7 @@ public:
         nCreateTime = 0;
         hdKeypath.clear();
         nChild = 0;
+        nChange = 0;
         hdMasterKeyID.SetNull();
     }
 };


### PR DESCRIPTION
- Output Key metadata in `dumpwallet`
- Restore Key metadata in `importwallet`
- Use Key metadata to restore `MintPool` objects from previous wallet, and sync mints with chain.