### PR TITLE
Patching Sigma Generator creation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2424,7 +2424,7 @@ bool CheckInputs(const CTransaction &tx, CValidationState &state, const CCoinsVi
             CDataStream serializedCoinSpend((const char *)&*(txin.scriptSig.begin() + 1),
                                             (const char *)&*txin.scriptSig.end(),
                                             SER_NETWORK, PROTOCOL_VERSION);
-            sigma::CoinSpend newSpend(sigma::SigmaParams, serializedCoinSpend);
+            sigma::CoinSpend newSpend(sigma::Params::get_default(), serializedCoinSpend);
             uint64_t denom = newSpend.getIntDenomination();
             totalInputValue += denom;
         }

--- a/src/secp256k1/include/GroupElement.h
+++ b/src/secp256k1/include/GroupElement.h
@@ -101,6 +101,8 @@ public:
 
   std::size_t hash() const;
 
+  void set_base_g();
+
   friend class MultiExponent;
 private:
     // Returns the secp object inside it.

--- a/src/secp256k1/src/cpp/GroupElement.cpp
+++ b/src/secp256k1/src/cpp/GroupElement.cpp
@@ -550,4 +550,8 @@ const void* GroupElement::get_value() const {
     return g_;
 }
 
+void GroupElement::set_base_g() {
+    secp256k1_gej_set_ge(reinterpret_cast<secp256k1_gej *>(g_), &secp256k1_ge_const_g);
+}
+
 } // namespace secp_primitives

--- a/src/sigma/params.cpp
+++ b/src/sigma/params.cpp
@@ -11,7 +11,7 @@ Params* Params::get_default() {
         //fixing generator G;
         GroupElement g;
 
-        if(::Params().GenConsensus().IsMain()) {
+        if(::Params().GetConsensus().IsMain()) {
             unsigned char buff[32] = {0};
             GroupElement base;
             base.set_base_g();

--- a/src/sigma/params.cpp
+++ b/src/sigma/params.cpp
@@ -11,7 +11,7 @@ Params* Params::get_default() {
         //fixing generator G;
         GroupElement g;
 
-        if(::Params().GetConsensus().IsMain()) {
+        if(!(::Params().GetConsensus().IsTestnet())) {
             unsigned char buff[32] = {0};
             GroupElement base;
             base.set_base_g();

--- a/src/sigma/params.cpp
+++ b/src/sigma/params.cpp
@@ -1,3 +1,4 @@
+#include "chainparams.h"
 #include "params.h"
 
 namespace sigma {
@@ -10,6 +11,13 @@ Params* Params::get_default() {
         //fixing generator G;
         GroupElement g("9216064434961179932092223867844635691966339998754536116709681652691785432045",
                        "33986433546870000256104618635743654523665060392313886665479090285075695067131");
+
+        if((::Params().NetworkIDString() == CBaseChainParams::MAIN)) {
+            unsigned char buff[32] = {0};
+            g.sha256(buff);
+            g.generate(buff);
+        }
+
         //fixing n and m; N = n^m = 16,384
         int n = 4;
         int m = 7;

--- a/src/sigma/params.cpp
+++ b/src/sigma/params.cpp
@@ -9,14 +9,18 @@ Params* Params::get_default() {
         return instance;
     else {
         //fixing generator G;
-        GroupElement g("9216064434961179932092223867844635691966339998754536116709681652691785432045",
-                       "33986433546870000256104618635743654523665060392313886665479090285075695067131");
+        GroupElement g;
 
-        if((::Params().NetworkIDString() == CBaseChainParams::MAIN)) {
+        if(::Params().GenConsensus().IsMain()) {
             unsigned char buff[32] = {0};
-            g.sha256(buff);
+            GroupElement base;
+            base.set_base_g();
+            base.sha256(buff);
             g.generate(buff);
         }
+        else
+            g = GroupElement("9216064434961179932092223867844635691966339998754536116709681652691785432045",
+                             "33986433546870000256104618635743654523665060392313886665479090285075695067131");
 
         //fixing n and m; N = n^m = 16,384
         int n = 4;

--- a/src/sigma/test/coin_spend_tests.cpp
+++ b/src/sigma/test/coin_spend_tests.cpp
@@ -5,9 +5,11 @@
 #include "../../streams.h"
 #include "../../uint256.h"
 
+#include "../../test/fixtures.h"
+
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_SUITE(sigma_coin_spend_tests)
+BOOST_FIXTURE_TEST_SUITE(sigma_coin_spend_tests, ZerocoinTestingSetup200)
 
 BOOST_AUTO_TEST_CASE(serialize_deserialize_test)
 {

--- a/src/sigma/test/coin_tests.cpp
+++ b/src/sigma/test/coin_tests.cpp
@@ -3,9 +3,11 @@
 
 #include "../../streams.h"
 
+#include "../../test/fixtures.h"
+
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_SUITE(sigma_coin_tests)
+BOOST_FIXTURE_TEST_SUITE(sigma_coin_tests, ZerocoinTestingSetup200)
 
 BOOST_AUTO_TEST_CASE(pubcoin_serialization)
 {

--- a/src/sigma/test/protocol_tests.cpp
+++ b/src/sigma/test/protocol_tests.cpp
@@ -4,7 +4,9 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_SUITE(sigma_protocol_tests)
+#include "../../test/fixtures.h"
+
+BOOST_FIXTURE_TEST_SUITE(sigma_protocol_tests, ZerocoinTestingSetup200)
 
 BOOST_AUTO_TEST_CASE(one_out_of_n)
 {

--- a/src/sigma/test/serialize_test.cpp
+++ b/src/sigma/test/serialize_test.cpp
@@ -4,7 +4,9 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_SUITE(sigma_serialize_tests)
+#include "../../test/fixtures.h"
+
+BOOST_FIXTURE_TEST_SUITE(sigma_serialize_tests, ZerocoinTestingSetup200)
 
 BOOST_AUTO_TEST_CASE(group_element_serialize)
 {

--- a/src/zerocoin_v3.cpp
+++ b/src/zerocoin_v3.cpp
@@ -28,9 +28,6 @@
 
 namespace sigma {
 
-// Set up the Sigma Params object
-sigma::Params* SigmaParams = sigma::Params::get_default();
-
 static CSigmaState sigmaState;
 
 static bool CheckSigmaSpendSerial(
@@ -99,7 +96,7 @@ std::pair<std::unique_ptr<sigma::CoinSpend>, uint32_t> ParseSigmaSpend(const CTx
         PROTOCOL_VERSION
     );
 
-    std::unique_ptr<sigma::CoinSpend> spend(new sigma::CoinSpend(SigmaParams, serialized));
+    std::unique_ptr<sigma::CoinSpend> spend(new sigma::CoinSpend(sigma::Params::get_default(), serialized));
 
     return std::make_pair(std::move(spend), groupId);
 }
@@ -459,7 +456,7 @@ bool CheckSigmaTransaction(
             CDataStream serializedCoinSpend((const char *)&*(txin.scriptSig.begin() + 1),
                                             (const char *)&*txin.scriptSig.end(),
                                             SER_NETWORK, PROTOCOL_VERSION);
-            sigma::CoinSpend newSpend(SigmaParams, serializedCoinSpend);
+            sigma::CoinSpend newSpend(sigma::Params::get_default(), serializedCoinSpend);
             uint64_t denom = newSpend.getIntDenomination();
             totalValue += denom;
             sigma::CoinDenomination denomination;
@@ -488,8 +485,8 @@ void RemoveSigmaSpendsReferencingBlock(CTxMemPool& pool, CBlockIndex* blockIndex
     for (CTxMemPool::txiter mi = pool.mapTx.begin(); mi != pool.mapTx.end(); ++mi) {
         const CTransaction& tx = mi->GetTx();
         if (tx.IsSigmaSpend()) {
-            // Run over all the inputs, check if their Accumulator block hash is equal to 
-            // block removed. If any one is equal, remove txn from mempool. 
+            // Run over all the inputs, check if their Accumulator block hash is equal to
+            // block removed. If any one is equal, remove txn from mempool.
             for (const CTxIn& txin : tx.vin) {
                 if (txin.IsSigmaSpend()) {
                     std::unique_ptr<sigma::CoinSpend> spend;
@@ -533,7 +530,7 @@ Scalar GetSigmaSpendSerialNumber(const CTransaction &tx, const CTxIn &txin) {
                 (const char *)&*(txin.scriptSig.begin() + 1),
                 (const char *)&*txin.scriptSig.end(),
                 SER_NETWORK, PROTOCOL_VERSION);
-        sigma::CoinSpend spend(SigmaParams, serializedCoinSpend);
+        sigma::CoinSpend spend(sigma::Params::get_default(), serializedCoinSpend);
         return spend.getCoinSerialNumber();
     }
     catch (const std::ios_base::failure &) {
@@ -555,7 +552,7 @@ CAmount GetSigmaSpendInput(const CTransaction &tx) {
                     (const char *)&*(txin.scriptSig.begin() + 1),
                     (const char *)&*txin.scriptSig.end(),
                     SER_NETWORK, PROTOCOL_VERSION);
-            sigma::CoinSpend spend(SigmaParams, serializedCoinSpend);
+            sigma::CoinSpend spend(sigma::Params::get_default(), serializedCoinSpend);
             sum += spend.getIntDenomination();
         }
         return sum;

--- a/src/zerocoin_v3.h
+++ b/src/zerocoin_v3.h
@@ -22,9 +22,6 @@ namespace zerocoin_tests3_v3 { struct zerocoin_mintspend_v3; }
 
 namespace sigma {
 
-// zerocoin parameters
-extern Params *SigmaParams;
-
 // Zerocoin transaction info, added to the CBlock to ensure zerocoin mint/spend transactions got their info stored into
 // index
 class CSigmaTxInfo {


### PR DESCRIPTION
A concern was brought up on the public verifiability of the randomness of g in the Sigma generator. While we aren't aware of how this can be exploited as there is no discrete log relationship between g and h, the team agreed that it was best practice to have the generation of g publicly verifiable.

This PR makes g as a hash of the base point of secp256k1 library.