### PR TITLE
Fix for dumpwallet in legacy/non-HD

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -712,8 +712,12 @@ UniValue dumpwallet(const UniValue& params, bool fHelp)
             }
             if(pwalletMain->mapKeyMetadata.find(keyid) != pwalletMain->mapKeyMetadata.end()){
                 if(pwalletMain->mapKeyMetadata[keyid].nVersion >= CKeyMetadata::VERSION_WITH_HDDATA){
-                    file << strprintf(" hdKeypath=%s", pwalletMain->mapKeyMetadata[keyid].hdKeypath);
-                    file << strprintf(" hdMasterKeyID=%s", pwalletMain->mapKeyMetadata[keyid].hdMasterKeyID.ToString());
+                    string hdKeypath = pwalletMain->mapKeyMetadata[keyid].hdKeypath;
+                    uint160 hdMasterKeyID = pwalletMain->mapKeyMetadata[keyid].hdMasterKeyID;
+                    if(hdKeypath != "")
+                        file << strprintf(" hdKeypath=%s", hdKeypath);
+                    if(!hdMasterKeyID.IsNull())
+                        file << strprintf(" hdMasterKeyID=%s", hdMasterKeyID.ToString());
                 }
             }
             file << strprintf(" # addr=%s\n", strAddr);


### PR DESCRIPTION
The check in` dumpwallet` for version of `CKeyMetadata` in not sufficient - With legacy and non-HD wallets, this check will still pass, even if the key created is not HD. So also check for existence of the relevant metadata.