### PR TITLE
Fix issue with parsing legacy HD keypath

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -515,8 +515,8 @@ UniValue importwallet(const UniValue& params, bool fHelp)
 
         if(fHd){
             // If change component in HD path is 2, this is a mint seed key. Add to mintpool. (Have to call after key addition)
-            if(pwalletMain->mapKeyMetadata[keyid].nChange==2){
-                zwalletMain->RegenerateMintPoolEntry(hdMasterKeyID, keyid, pwalletMain->mapKeyMetadata[keyid].nChild);
+            if(pwalletMain->mapKeyMetadata[keyid].nChange.first==2){
+                zwalletMain->RegenerateMintPoolEntry(hdMasterKeyID, keyid, pwalletMain->mapKeyMetadata[keyid].nChild.first);
                 fMintUpdate = true;
             }
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -145,7 +145,7 @@ CPubKey CWallet::GenerateNewKey(uint32_t nChange) {
     // Create new metadata
     int64_t nCreationTime = GetTime();
     CKeyMetadata metadata(nCreationTime);
-    metadata.nChange = nChange;
+    metadata.nChange = Component(nChange, false);
 
     boost::optional<bool> regTest = GetOptBoolArg("-regtest")
     , testNet = GetOptBoolArg("-testnet");
@@ -187,7 +187,7 @@ CPubKey CWallet::GenerateNewKey(uint32_t nChange) {
             externalChainChildKey.Derive(childKey, hdChain.nExternalChainCounters[nChange]);
             metadata.hdKeypath = "m/44'/" + std::to_string(nIndex) + "'/0'/" + std::to_string(nChange) + "/" + std::to_string(hdChain.nExternalChainCounters[nChange]);
             metadata.hdMasterKeyID = hdChain.masterKeyID;
-            metadata.nChild = hdChain.nExternalChainCounters[nChange];
+            metadata.nChild = Component(hdChain.nExternalChainCounters[nChange], false);
             // increment childkey index
             hdChain.nExternalChainCounters[nChange]++;
         } while (HaveKey(childKey.key.GetPubKey().GetID()));

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -58,6 +58,9 @@ enum DBErrors
     DB_NEED_REWRITE
 };
 
+// {value, isHardened}
+typedef pair<int64_t,bool> Component;
+
 /* simple HD chain data model */
 class CHDChain
 {
@@ -107,8 +110,8 @@ public:
     int nVersion;
     int64_t nCreateTime; // 0 means unknown
     std::string hdKeypath; //optional HD/bip32 keypath
-    int64_t nChange; // HD/bip32 keypath change counter
-    int64_t nChild; // HD/bip32 keypath child counter
+    Component nChange; // HD/bip32 keypath change counter
+    Component nChild; // HD/bip32 keypath child counter
     CKeyID hdMasterKeyID; //id of the HD masterkey used to derive this key
 
     CKeyMetadata()
@@ -125,11 +128,18 @@ public:
         std::vector<std::string> nComponents;
         if(hdKeypath=="m")
             return false;
-        std::string hdKeypathNonHardened = hdKeypath;
-        boost::erase_all(hdKeypathNonHardened, "'");
-        boost::split(nComponents, hdKeypathNonHardened, boost::is_any_of("/"), boost::token_compress_on);
-        nChange = boost::lexical_cast<int64_t>(nComponents[nComponents.size()-2]);
-        nChild = boost::lexical_cast<int64_t>(nComponents[nComponents.size()-1]);
+        boost::split(nComponents, hdKeypath, boost::is_any_of("/"), boost::token_compress_on);
+        std::string nChangeStr = nComponents[nComponents.size()-2];
+        std::string nChildStr  = nComponents[nComponents.size()-1];
+
+        nChange.second = (nChangeStr.find("'") != string::npos);
+        boost::erase_all(nChangeStr, "'");
+        nChange.first = boost::lexical_cast<int64_t>(nChangeStr);
+
+        nChild.second = (nChildStr.find("'") != string::npos);
+        boost::erase_all(nChildStr, "'");
+        nChild.first = boost::lexical_cast<int64_t>(nChildStr);
+
         return true;
     }
 
@@ -152,8 +162,8 @@ public:
         nVersion = CKeyMetadata::CURRENT_VERSION;
         nCreateTime = 0;
         hdKeypath.clear();
-        nChild = 0;
-        nChange = 0;
+        nChild = Component(0, false);
+        nChange = Component(0, false);
         hdMasterKeyID.SetNull();
     }
 };

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -59,7 +59,7 @@ enum DBErrors
 };
 
 // {value, isHardened}
-typedef pair<int64_t,bool> Component;
+typedef pair<uint32_t,bool> Component;
 
 /* simple HD chain data model */
 class CHDChain

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -26,6 +26,7 @@
 #include "libzerocoin/Zerocoin.h"
 
 #include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/erase.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -124,9 +125,11 @@ public:
         std::vector<std::string> nComponents;
         if(hdKeypath=="m")
             return false;
-        boost::split(nComponents, hdKeypath, boost::is_any_of("/"), boost::token_compress_on);
-        nChange = boost::lexical_cast<int64_t>(nComponents[4]);
-        nChild = boost::lexical_cast<int64_t>(nComponents[5]);
+        std::string hdKeypathNonHardened = hdKeypath;
+        boost::erase_all(hdKeypathNonHardened, "'");
+        boost::split(nComponents, hdKeypathNonHardened, boost::is_any_of("/"), boost::token_compress_on);
+        nChange = boost::lexical_cast<int64_t>(nComponents[nComponents.size()-2]);
+        nChild = boost::lexical_cast<int64_t>(nComponents[nComponents.size()-1]);
         return true;
     }
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -134,11 +134,11 @@ public:
 
         nChange.second = (nChangeStr.find("'") != string::npos);
         boost::erase_all(nChangeStr, "'");
-        nChange.first = boost::lexical_cast<int64_t>(nChangeStr);
+        nChange.first = boost::lexical_cast<uint32_t>(nChangeStr);
 
         nChild.second = (nChildStr.find("'") != string::npos);
         boost::erase_all(nChildStr, "'");
-        nChild.first = boost::lexical_cast<int64_t>(nChildStr);
+        nChild.first = boost::lexical_cast<uint32_t>(nChildStr);
 
         return true;
     }


### PR DESCRIPTION
Fixes issue where old keypath format does not parse correctly in `importwallet`. Also adds information on hardened components to `CKeyMetadata`