### PR TITLE
Update database counter for reminted change

### DIFF
--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -453,10 +453,12 @@ void CHDMintWallet::SetCount(int32_t nCount)
 void CHDMintWallet::UpdateCountLocal()
 {
     nCountNextUse++;
+    LogPrintf("CHDMintWallet : Updating count local to %s\n",nCountNextUse);
 }
 
 void CHDMintWallet::UpdateCountDB()
 {
+    LogPrintf("CHDMintWallet : Updating count in DB to %s\n",nCountNextUse);	
     CWalletDB walletdb(strWalletFile);
     walletdb.WriteZerocoinCount(nCountNextUse);
     GenerateMintPool();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -7005,6 +7005,8 @@ bool CWallet::CommitSigmaTransaction(CWalletTx& wtxNew, std::vector<CSigmaEntry>
             CT_NEW);
     }
 
+    // Update nCountNextUse in HDMint wallet database
+    zwalletMain->UpdateCountDB();
 
     return true;
 }


### PR DESCRIPTION
## PR intention
The internal counter that chooses the next mint to use for change is not being updated. As a result, following a sigma spend involving reminting, the subsequent transaction uses the same mint as as the one previous.

## Code changes brief
- Add `UpdateCountDB()` to `CommitSigmaTransaction`. This simply writes the current `nCountLastUse` to the DB. If it hasn't changed, it has no effect.

- Increased verbosity of logging for mint count
