### PR TITLE
Fixed bug in sigma spend tx creation

### DIFF
--- a/src/sigma.cpp
+++ b/src/sigma.cpp
@@ -1005,6 +1005,8 @@ int CSigmaState::GetCoinSetForSpend(
         uint256& blockHash_out,
         std::vector<sigma::PublicCoin>& coins_out) {
 
+    coins_out.clear();
+
     pair<sigma::CoinDenomination, int> denomAndId = std::make_pair(denomination, coinGroupID);
 
     if (coinGroups.count(denomAndId) == 0)


### PR DESCRIPTION
## PR intention
Fixes rare bug in creating sigma spend transaction

## Code changes brief
CSigmaState::GetCoinSetForSpend() added items to its output without clearing it first. This PR fixes this behavior.
