### PR TITLE
Sigma index fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ src/qt/forms/ui_*.h
 src/qt/test/moc*.cpp
 
 src/tor.timestamp*
+src/tor/src/or
 
 .deps
 .dirstamp

--- a/src/sigma.cpp
+++ b/src/sigma.cpp
@@ -945,14 +945,10 @@ void CSigmaState::RemoveBlock(CBlockIndex *index) {
         }
     }
 
-    index->sigmaMintedPubCoins.clear();
-
     // roll back spends
     BOOST_FOREACH(const spend_info_container::value_type &serial, index->sigmaSpentSerials) {
         containers.RemoveSpend(serial.first);
     }
-
-    index->sigmaSpentSerials.clear();
 }
 
 bool CSigmaState::GetCoinGroupInfo(


### PR DESCRIPTION
## PR intention
It's possible for the block that removed from the blockchain to be re-inserted back later. This PR fixes rare condition of not re-adding spends and mints into the index after such operation

## Code changes brief
In CSigmaState::RemoveBlock() clearing mints and spends from the block index should not be done