### PR TITLE
Fixed another znode-related deadlock

### DIFF
--- a/src/znodeman.h
+++ b/src/znodeman.h
@@ -313,7 +313,7 @@ public:
     void ProcessVerifyBroadcast(CNode* pnode, const CZnodeVerification& mnv);
 
     /// Return the number of (unique) Znodes
-    int size() { LOCK(cs); return vZnodes.size(); }
+    int size() { return vZnodes.size(); }
 
     std::string ToString() const;
 


### PR DESCRIPTION
## PR intention
Fix deadlock in znode code

## Code changes brief
Fixed this race condition:
```
2019-08-14 11:06:37 POTENTIAL DEADLOCK DETECTED
2019-08-14 11:06:37 Previous lock order was:
2019-08-14 11:06:37  (1) cs_mapZnodeBlocks  znode-payments.cpp:603
2019-08-14 11:06:37  cs_mapZnodePaymentVotes  znode-payments.cpp:603
2019-08-14 11:06:37  (2) cs  znodeman.h:316
2019-08-14 11:06:37 Current lock order is:
2019-08-14 11:06:37  (2) cs  znodeman.cpp:1576
2019-08-14 11:06:37  (1) cs_mapZnodeBlocks  znode.cpp:410
```
with removal of extra unneeded lock