### PR TITLE
Add transaction processor

### DIFF
--- a/src/Makefile.exodus.include
+++ b/src/Makefile.exodus.include
@@ -16,6 +16,7 @@ EXODUS_H = \
   exodus/parse_string.h \
   exodus/pending.h \
   exodus/persistence.h \
+  exodus/property.h \
   exodus/rpc.h \
   exodus/rpcpayload.h \
   exodus/rpcrawtx.h \
@@ -30,6 +31,7 @@ EXODUS_H = \
   exodus/sto.h \
   exodus/tally.h \
   exodus/tx.h \
+  exodus/txprocessor.h \
   exodus/uint256_extensions.h \
   exodus/utils.h \
   exodus/utilsbitcoin.h \
@@ -68,6 +70,7 @@ EXODUS_CPP = \
   exodus/sto.cpp \
   exodus/tally.cpp \
   exodus/tx.cpp \
+  exodus/txprocessor.cpp \
   exodus/utils.cpp \
   exodus/utilsbitcoin.cpp \
   exodus/version.cpp \

--- a/src/exodus/exodus.cpp
+++ b/src/exodus/exodus.cpp
@@ -4,54 +4,55 @@
  * This file contains the core of Exodus Core.
  */
 
-#include "exodus/exodus.h"
+#include "exodus.h"
 
-#include "exodus/activation.h"
-#include "exodus/consensushash.h"
-#include "exodus/convert.h"
-#include "exodus/dex.h"
-#include "exodus/encoding.h"
-#include "exodus/errors.h"
-#include "exodus/fees.h"
-#include "exodus/log.h"
-#include "exodus/mdex.h"
-#include "exodus/notifications.h"
-#include "exodus/pending.h"
-#include "exodus/persistence.h"
-#include "exodus/rules.h"
-#include "exodus/script.h"
-#include "exodus/sigmadb.h"
-#include "exodus/sp.h"
-#include "exodus/tally.h"
-#include "exodus/tx.h"
-#include "exodus/utils.h"
-#include "exodus/utilsbitcoin.h"
-#include "exodus/version.h"
-#include "exodus/walletcache.h"
-#include "exodus/wallettxs.h"
+#include "activation.h"
+#include "consensushash.h"
+#include "convert.h"
+#include "dex.h"
+#include "encoding.h"
+#include "errors.h"
+#include "fees.h"
+#include "log.h"
+#include "mdex.h"
+#include "notifications.h"
+#include "pending.h"
+#include "persistence.h"
+#include "rules.h"
+#include "script.h"
+#include "sigmadb.h"
+#include "sp.h"
+#include "tally.h"
+#include "tx.h"
+#include "txprocessor.h"
+#include "utils.h"
+#include "utilsbitcoin.h"
+#include "version.h"
+#include "walletcache.h"
+#include "wallettxs.h"
 
-#include "base58.h"
-#include "chainparams.h"
-#include "coincontrol.h"
-#include "coins.h"
-#include "core_io.h"
-#include "init.h"
-#include "main.h"
-#include "primitives/block.h"
-#include "primitives/transaction.h"
-#include "script/script.h"
-#include "script/standard.h"
-#include "sync.h"
-#include "tinyformat.h"
-#include "uint256.h"
-#include "ui_interface.h"
-#include "util.h"
-#include "utilstrencodings.h"
-#include "utiltime.h"
-#include "sigma.h"
+#include "../base58.h"
+#include "../chainparams.h"
+#include "../coincontrol.h"
+#include "../coins.h"
+#include "../core_io.h"
+#include "../init.h"
+#include "../main.h"
+#include "../primitives/block.h"
+#include "../primitives/transaction.h"
+#include "../script/script.h"
+#include "../script/standard.h"
+#include "../sync.h"
+#include "../tinyformat.h"
+#include "../uint256.h"
+#include "../ui_interface.h"
+#include "../util.h"
+#include "../utilstrencodings.h"
+#include "../utiltime.h"
+#include "../sigma.h"
 #ifdef ENABLE_WALLET
-#include "script/ismine.h"
-#include "wallet/wallet.h"
+#include "../script/ismine.h"
+#include "../wallet/wallet.h"
 #endif
 
 #include <univalue.h>
@@ -2380,8 +2381,12 @@ bool exodus_handler_tx(const CTransaction& tx, int nBlock, unsigned int idx, con
     int pop_ret = parseTransaction(false, tx, nBlock, idx, mp_obj, nBlockTime);
 
     if (0 == pop_ret) {
-        int interp_ret = mp_obj.interpretPacket();
-        if (interp_ret) PrintToLog("!!! interpretPacket() returned %d !!!\n", interp_ret);
+        TxProcessor processor;
+
+        int interp_ret = processor.ProcessTx(mp_obj);
+        if (interp_ret) {
+            PrintToLog("!!! interpretPacket() returned %d !!!\n", interp_ret);
+        }
 
         // Only structurally valid transactions get recorded in levelDB
         // PKT_ERROR - 2 = interpret_Transaction failed, structurally invalid payload
@@ -2708,11 +2713,14 @@ bool CMPTxList::LoadFreezeState(int blockHeight)
             PrintToLog("ERROR: While loading freeze transaction %s: levelDB type mismatch, not a freeze transaction.\n", hash.GetHex());
             return false;
         }
-        mp_obj.unlockLogic();
-        if (0 != mp_obj.interpretPacket()) {
+
+        TxProcessor processor;
+
+        if (0 != processor.ProcessTx(mp_obj)) {
             PrintToLog("ERROR: While loading freeze transaction %s: non-zero return from interpretPacket\n", hash.GetHex());
             return false;
         }
+
         txnsLoaded++;
     }
 
@@ -2778,8 +2786,10 @@ void CMPTxList::LoadActivations(int blockHeight)
             PrintToLog("ERROR: While loading activation transaction %s: levelDB type mismatch, not an activation.\n", hash.GetHex());
             continue;
         }
-        mp_obj.unlockLogic();
-        if (0 != mp_obj.interpretPacket()) {
+
+        TxProcessor processor;
+
+        if (0 != processor.ProcessTx(mp_obj)) {
             PrintToLog("ERROR: While loading activation transaction %s: non-zero return from interpretPacket\n", hash.GetHex());
             continue;
         }

--- a/src/exodus/property.h
+++ b/src/exodus/property.h
@@ -1,0 +1,12 @@
+#ifndef ZCOIN_EXODUS_PROPERTY_H
+#define ZCOIN_EXODUS_PROPERTY_H
+
+#include <cinttypes>
+
+namespace exodus {
+
+typedef std::uint32_t PropertyId;
+
+}
+
+#endif // ZCOIN_EXODUS_PROPERTY_H

--- a/src/exodus/sigma.h
+++ b/src/exodus/sigma.h
@@ -11,6 +11,7 @@
 
 #include <boost/optional.hpp>
 
+#include <cinttypes>
 #include <iterator>
 #include <stdexcept>
 #include <vector>
@@ -19,6 +20,8 @@
 #include <stddef.h>
 
 namespace exodus {
+
+// Sigma Cryptographic Primitives.
 
 class SigmaPrivateKey
 {
@@ -165,6 +168,10 @@ private:
     secp_primitives::Scalar serial;
     sigma::SigmaPlusProof<secp_primitives::Scalar, secp_primitives::GroupElement> proof;
 };
+
+// Exodus Specific.
+
+typedef std::uint8_t DenominationId;
 
 } // namespace exodus
 

--- a/src/exodus/sigmadb.h
+++ b/src/exodus/sigmadb.h
@@ -4,12 +4,12 @@
 #include "convert.h"
 #include "persistence.h"
 #include "sigma.h"
-#include "log.h"
 
 #include <univalue.h>
 
 #include <boost/filesystem/path.hpp>
 
+#include <cinttypes>
 #include <string>
 #include <vector>
 
@@ -27,8 +27,9 @@ struct is_iterator<T, typename std::enable_if<!std::is_same<typename std::iterat
 
 namespace exodus {
 
-/** LevelDB based storage for sigma mints, with
-*/
+typedef std::uint32_t MintGroupId;
+typedef std::uint16_t MintGroupIndex;
+
 class CMPMintList : public CDBBase
 {
 public:

--- a/src/exodus/tx.cpp
+++ b/src/exodus/tx.cpp
@@ -37,11 +37,6 @@ using boost::algorithm::token_compress_on;
 
 using namespace exodus;
 
-namespace exodus
-{
-boost::signals2::signal<void (CMPTransaction const &)> NotifyProcessedTransaction;
-};
-
 /** Returns a label for the given transaction type. */
 std::string exodus::strTransactionType(uint16_t txType)
 {
@@ -1094,9 +1089,6 @@ int CMPTransaction::interpretPacket()
             return (PKT_ERROR -100);
     }
 
-    if (!status) {
-        exodus::NotifyProcessedTransaction(*this);
-    }
     return status;
 }
 

--- a/src/exodus/tx.h
+++ b/src/exodus/tx.h
@@ -157,7 +157,6 @@ private:
     int logicMath_FreezeTokens();
     int logicMath_UnfreezeTokens();
     int logicMath_CreateDenomination();
-    int logicMath_SimpleMint();
     int logicMath_Activation();
     int logicMath_Deactivation();
     int logicMath_Alert();
@@ -186,13 +185,14 @@ public:
     };
 
     uint256 getHash() const { return txid; }
+    int getBlock() const { return block; }
     unsigned int getType() const { return type; }
     std::string getTypeString() const { return strTransactionType(getType()); }
     unsigned int getProperty() const { return property; }
     unsigned short getVersion() const { return version; }
     unsigned short getPropertyType() const { return prop_type; }
     uint64_t getFeePaid() const { return tx_fee_paid; }
-    std::string getSender() const { return sender; }
+    const std::string& getSender() const { return sender; }
     std::string getReceiver() const { return receiver; }
     std::string getPayload() const { return HexStr(pkt, pkt + pkt_size); }
     uint64_t getAmount() const { return nValue; }

--- a/src/exodus/tx.h
+++ b/src/exodus/tx.h
@@ -321,9 +321,4 @@ public:
 /** Parses a transaction and populates the CMPTransaction object. */
 int ParseTransaction(const CTransaction& tx, int nBlock, unsigned int idx, CMPTransaction& mptx, unsigned int nTime=0);
 
-namespace exodus
-{
-extern boost::signals2::signal<void (CMPTransaction const &)> NotifyProcessedTransaction;
-};
-
 #endif // ZCOIN_EXODUS_TX_H

--- a/src/exodus/txprocessor.cpp
+++ b/src/exodus/txprocessor.cpp
@@ -1,0 +1,16 @@
+#include "txprocessor.h"
+
+namespace exodus {
+
+int TxProcessor::ProcessTx(CMPTransaction& tx)
+{
+    tx.unlockLogic();
+
+    auto result = tx.interpretPacket();
+
+    TransactionProcessed(tx);
+
+    return result;
+}
+
+}

--- a/src/exodus/txprocessor.cpp
+++ b/src/exodus/txprocessor.cpp
@@ -1,16 +1,138 @@
 #include "txprocessor.h"
 
+#include "rules.h"
+
 namespace exodus {
+
+TxProcessor *txProcessor;
+
+namespace {
+
+bool IsSigmaEnabled(uint32_t propertyId)
+{
+    CMPSPInfo::Entry sp;
+
+    if (!_my_sps->getSP(propertyId, sp)) {
+        return false;
+    }
+
+    if (sp.sigmaStatus != SigmaStatus::HardEnabled && sp.sigmaStatus != SigmaStatus::SoftEnabled) {
+        return false;
+    }
+
+    return true;
+}
+
+} // unnamed namespace
 
 int TxProcessor::ProcessTx(CMPTransaction& tx)
 {
+    LOCK(cs_tally);
+
     tx.unlockLogic();
 
     auto result = tx.interpretPacket();
 
+    if (result == (PKT_ERROR - 100)) {
+        // Unknow transaction type.
+        switch (tx.getType()) {
+        case EXODUS_TYPE_SIGMA_SIMPLE_MINT:
+            result = ProcessSimpleMint(tx);
+            break;
+        }
+    }
+
+    if (result) {
+        return result; // Error.
+    }
+
     TransactionProcessed(tx);
 
-    return result;
+    return 0;
+}
+
+int TxProcessor::ProcessSimpleMint(const CMPTransaction& tx)
+{
+    auto block = tx.getBlock();
+    auto type = tx.getType();
+    auto version = tx.getVersion();
+    auto property = tx.getProperty();
+
+    if (!IsTransactionTypeAllowed(block, property, type, version)) {
+        PrintToLog("%s(): rejected: type %d or version %d not permitted for property %d at block %d\n",
+            __func__,
+            type,
+            version,
+            property,
+            block
+        );
+        return PKT_ERROR_SIGMA - 22;
+    }
+
+    if (!IsPropertyIdValid(property)) {
+        PrintToLog("%s(): rejected: property %d does not exist\n", __func__, property);
+        return PKT_ERROR_SIGMA - 24;
+    }
+
+    if (!IsSigmaEnabled(property)) {
+        PrintToLog("%s(): rejected: property %d does not enable sigma\n", __func__, property);
+        return PKT_ERROR_SIGMA - 901;
+    }
+
+    std::vector<DenominationId> denominations;
+    denominations.reserve(tx.getMints().size());
+
+    for (auto &mint : tx.getMints()) {
+        auto denom = mint.first;
+        auto& pubkey = mint.second;
+
+        if (!pubkey.IsValid()) {
+            PrintToLog("%s(): rejected: public key is invalid\n", __func__);
+            return PKT_ERROR_SIGMA - 904;
+        }
+
+        denominations.push_back(denom);
+    }
+
+    int64_t amount;
+    try {
+        amount = SumDenominationsValue(property, denominations.begin(), denominations.end());
+    } catch (const std::invalid_argument& e) {
+        // The only possible cases is invalid denomination.
+        PrintToLog("%s(): rejected: error %s\n", __func__, e.what());
+        return PKT_ERROR_SIGMA - 905;
+    }
+
+    auto& sender = tx.getSender();
+    int64_t balance = getMPbalance(sender, property, BALANCE);
+
+    if (balance < amount) {
+        PrintToLog("%s(): rejected: sender %s has insufficient balance of property %d [%s < %s]\n",
+            __func__,
+            tx.getSender(),
+            property,
+            FormatMP(property, balance),
+            FormatMP(property, amount)
+        );
+        return PKT_ERROR_SIGMA - 25;
+    }
+
+    // subtract balance
+    assert(update_tally_map(sender, property, -amount, BALANCE));
+
+    for (auto &mint : tx.getMints()) {
+        MintGroupId group;
+        MintGroupIndex index;
+
+        auto denom = mint.first;
+        auto& pubkey = mint.second;
+
+        std::tie(group, index) = p_mintlistdb->RecordMint(property, denom, pubkey, block);
+
+        SimpleMintProcessed(property, denom, group, index, pubkey);
+    }
+
+    return 0;
 }
 
 }

--- a/src/exodus/txprocessor.h
+++ b/src/exodus/txprocessor.h
@@ -1,0 +1,21 @@
+#ifndef ZCOIN_EXODUS_TXPROCESSOR_H
+#define ZCOIN_EXODUS_TXPROCESSOR_H
+
+#include "tx.h"
+
+#include <boost/signals2/signal.hpp>
+
+namespace exodus {
+
+class TxProcessor
+{
+public:
+    int ProcessTx(CMPTransaction& tx);
+
+public:
+    boost::signals2::signal<void(const CMPTransaction&)> TransactionProcessed;
+};
+
+}
+
+#endif // ZCOIN_EXODUS_TXPROCESSOR_H

--- a/src/exodus/txprocessor.h
+++ b/src/exodus/txprocessor.h
@@ -1,6 +1,9 @@
 #ifndef ZCOIN_EXODUS_TXPROCESSOR_H
 #define ZCOIN_EXODUS_TXPROCESSOR_H
 
+#include "property.h"
+#include "sigma.h"
+#include "sigmadb.h"
 #include "tx.h"
 
 #include <boost/signals2/signal.hpp>
@@ -13,8 +16,14 @@ public:
     int ProcessTx(CMPTransaction& tx);
 
 public:
+    boost::signals2::signal<void(PropertyId, DenominationId, MintGroupId, MintGroupIndex, const SigmaPublicKey&)> SimpleMintProcessed;
     boost::signals2::signal<void(const CMPTransaction&)> TransactionProcessed;
+
+private:
+    int ProcessSimpleMint(const CMPTransaction& tx);
 };
+
+extern TxProcessor *txProcessor;
 
 }
 


### PR DESCRIPTION
## PR intention
Decoupled logic from `tx.cpp`.

## Code changes brief
Change the way to process transactions from `CMPTransaction.interpretPacket` to a new class. Right now only simple mint get processed with this way. We will move other transactions later. From now on a new transaction processor should put into a new class.