### PR TITLE
Entry type fix

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -484,6 +484,8 @@ UniValue importwallet(const UniValue& params, bool fHelp)
                 break;
             if (vstr[nStr] == "change=1")
                 fLabel = false;
+            if (vstr[nStr] == "sigma=1")
+                fLabel = false;
             if (vstr[nStr] == "reserve=1")
                 fLabel = false;
             if (boost::algorithm::starts_with(vstr[nStr], "label=")) {
@@ -696,6 +698,7 @@ UniValue dumpwallet(const UniValue& params, bool fHelp)
         const CKeyID &keyid = it->second;
         std::string strTime = EncodeDumpTime(it->first);
         std::string strAddr = CBitcoinAddress(keyid).ToString();
+	pwalletMain->mapKeyMetadata[keyid].ParseComponents();
         CKey key;
         if (pwalletMain->GetKey(keyid, key)) {
             file << strprintf("%s %s ", CBitcoinSecret(key).ToString(), strTime);
@@ -707,6 +710,8 @@ UniValue dumpwallet(const UniValue& params, bool fHelp)
                 file << "reserve=1";
             } else if (pwalletMain->mapKeyMetadata[keyid].hdKeypath == "m") {
                 file << "inactivehdmaster=1";
+	    } else if (pwalletMain->mapKeyMetadata[keyid].nChange.first == 2) {
+                file << "sigma=1";
             } else {
                 file << "change=1";
             }


### PR DESCRIPTION
## PR intention
Fixes https://github.com/zcoinofficial/zcoin/issues/602
Changes entry type for HD mint keys from `change` to `sigma`. This is backwards compatible as it is cosmetic only.

## Code changes brief
Updates to code and tests
