### PR TITLE
Entry type fix

### DIFF
--- a/qa/rpc-tests/wallet-dump.py
+++ b/qa/rpc-tests/wallet-dump.py
@@ -60,7 +60,7 @@ def read_dump(file_name, addrs, hd_master_addr_old):
                     elif keytype == "sigma=1":
                         found_addr_sigma += 1
                         break
-        return found_addr, found_addr_chg, found_addr_rsv, found_addr_sigma, hd_master_addr_re
+        return found_addr, found_addr_chg, found_addr_rsv, found_addr_sigma, hd_master_addr_ret
 
 
 class WalletDumpTest(BitcoinTestFramework):
@@ -108,7 +108,8 @@ class WalletDumpTest(BitcoinTestFramework):
             read_dump(tmpdir + "/node0/wallet.unencrypted.dump", addrs, None)
         assert_equal(found_addr, test_addr_count)  # all keys must be in the dump
 
-        assert_equal(found_addr_chg, 50 + hdmint_key_count) # 50 block were mined + hdmint keys
+        assert_equal(found_addr_chg, 50) # 50 block were mined
+        assert_equal(found_addr_sigma, hdmint_key_count) # hdmint keys
         assert_equal(found_addr_rsv, 90 + 1)  # keypool size (TODO: fix off-by-one)
 
         #encrypt wallet, restart, unlock and dump

--- a/qa/rpc-tests/wallet-dump.py
+++ b/qa/rpc-tests/wallet-dump.py
@@ -17,6 +17,7 @@ def read_dump(file_name, addrs, hd_master_addr_old):
         found_addr = 0
         found_addr_chg = 0
         found_addr_rsv = 0
+        found_addr_sigma = 0
         hd_master_addr_ret = None
         for line in inputfile:
             # only read non comment lines
@@ -56,7 +57,10 @@ def read_dump(file_name, addrs, hd_master_addr_old):
                     elif keytype == "reserve=1":
                         found_addr_rsv += 1
                         break
-        return found_addr, found_addr_chg, found_addr_rsv, hd_master_addr_ret
+                    elif keytype == "sigma=1":
+                        found_addr_sigma += 1
+                        break
+        return found_addr, found_addr_chg, found_addr_rsv, found_addr_sigma, hd_master_addr_re
 
 
 class WalletDumpTest(BitcoinTestFramework):
@@ -100,7 +104,7 @@ class WalletDumpTest(BitcoinTestFramework):
             self.nodes[0].dumpwallet(tmpdir + "/node0/wallet.unencrypted.dump", key)
         assert key, 'Import wallet did not raise exception when was called first time without one-time code.'
 
-        found_addr, found_addr_chg, found_addr_rsv, hd_master_addr_unenc = \
+        found_addr, found_addr_chg, found_addr_rsv, found_addr_sigma, hd_master_addr_unenc = \
             read_dump(tmpdir + "/node0/wallet.unencrypted.dump", addrs, None)
         assert_equal(found_addr, test_addr_count)  # all keys must be in the dump
 
@@ -122,13 +126,14 @@ class WalletDumpTest(BitcoinTestFramework):
             self.nodes[0].dumpwallet(tmpdir + "/node0/wallet.encrypted.dump", key)
         assert key, 'Import wallet did not raise exception when was called first time without one-time code.'
 
-        found_addr, found_addr_chg, found_addr_rsv, hd_master_addr_enc = \
+        found_addr, found_addr_chg, found_addr_rsv, found_addr_sigma, hd_master_addr_enc = \
             read_dump(tmpdir + "/node0/wallet.encrypted.dump", addrs, hd_master_addr_unenc)
         assert_equal(found_addr, test_addr_count)
         
-        # - old reserve keys are marked as change now
-        # - As wallet encryption creates a new master seed, it adds another set of hdmint keys.
-        assert_equal(found_addr_chg, 90 + 1 + 50 + (hdmint_key_count * 2))
+        # old reserve keys are marked as change now
+        assert_equal(found_addr_chg, 90 + 1 + 50)
+        # As wallet encryption creates a new master seed, it adds another set of hdmint keys.
+        assert_equal(found_addr_sigma, hdmint_key_count * 2)
         assert_equal(found_addr_rsv, 90 + 1)  # keypool size (TODO: fix off-by-one)
 
 if __name__ == '__main__':

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -484,6 +484,8 @@ UniValue importwallet(const UniValue& params, bool fHelp)
                 break;
             if (vstr[nStr] == "change=1")
                 fLabel = false;
+            if (vstr[nStr] == "sigma=1")
+                fLabel = false;
             if (vstr[nStr] == "reserve=1")
                 fLabel = false;
             if (boost::algorithm::starts_with(vstr[nStr], "label=")) {
@@ -697,6 +699,7 @@ UniValue dumpwallet(const UniValue& params, bool fHelp)
         std::string strTime = EncodeDumpTime(it->first);
         std::string strAddr = CBitcoinAddress(keyid).ToString();
         CKey key;
+        pwalletMain->mapKeyMetadata[keyid].ParseComponents();
         if (pwalletMain->GetKey(keyid, key)) {
             file << strprintf("%s %s ", CBitcoinSecret(key).ToString(), strTime);
             if (pwalletMain->mapAddressBook.count(keyid)) {
@@ -707,6 +710,8 @@ UniValue dumpwallet(const UniValue& params, bool fHelp)
                 file << "reserve=1";
             } else if (pwalletMain->mapKeyMetadata[keyid].hdKeypath == "m") {
                 file << "inactivehdmaster=1";
+            } else if (pwalletMain->mapKeyMetadata[keyid].nChange.first == 2) {
+                file << "sigma=1";
             } else {
                 file << "change=1";
             }


### PR DESCRIPTION
## PR intention
Fixes https://github.com/zcoinofficial/zcoin/issues/602
Changes entry type for HD mint keys from `change` to `sigma`. This is backwards compatible as it is cosmetic only.

## Code changes brief
Updates to code and tests
