### PR TITLE
fix for help RPC call requiring passphrase

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2654,6 +2654,11 @@ UniValue fundrawtransaction(const UniValue& params, bool fHelp)
 
 UniValue regeneratemintpool(const UniValue &params, bool fHelp) {
 
+        if (fHelp || params.size() > 0)
+	        throw runtime_error(
+       	        	"regeneratemintpool\n"
+       		        "\nIf issues exist with the keys that map to mintpool entries in the DB, this function corrects them.\n"
+                );
     if (pwalletMain->IsLocked())
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED,
                            "Error: Please enter the wallet passphrase with walletpassphrase first.");

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2658,6 +2658,9 @@ UniValue regeneratemintpool(const UniValue &params, bool fHelp) {
 	        throw runtime_error(
        	        	"regeneratemintpool\n"
        		        "\nIf issues exist with the keys that map to mintpool entries in the DB, this function corrects them.\n"
+                    "\nExamples:\n"
+                    + HelpExampleCli("regeneratemintpool", "")
+                    + HelpExampleRpc("regeneratemintpool", "")
                 );
     if (pwalletMain->IsLocked())
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED,
@@ -2702,9 +2705,9 @@ UniValue regeneratemintpool(const UniValue &params, bool fHelp) {
     }
 
     if(reindexRequired)
-        return "Mintpool issue corrected. Please shutdown zcoin and restart with -reindex flag.";
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "Mintpool issue corrected. Please shutdown zcoin and restart with -reindex flag.");
 
-    return "No issues with mintpool detected.";
+    return true;
 }
 
 //[zcoin]: zerocoin section


### PR DESCRIPTION
Fixes https://github.com/zcoinofficial/zcoin/issues/672

## PR intention
The result of the `help` call with a locked & encrypted wallet is currently:
```
Error: Please enter the wallet passphrase with walletpassphrase first.
```
The issue is that the function `regeneratemintpool` does not have a `help` section, but requires wallet unlock. This PR adds that and makes the `help` function accessible from a locked wallet again.
