### PR TITLE
Remove params from sigmaplus proof

### DIFF
--- a/src/sigma/coinspend.cpp
+++ b/src/sigma/coinspend.cpp
@@ -16,7 +16,7 @@ CoinSpend::CoinSpend(
     coinSerialNumber(coin.getSerialNumber()),
     ecdsaSignature(64, 0),
     ecdsaPubkey(33, 0),
-    sigmaProof(p)
+    sigmaProof(p->get_n(), p->get_m())
 {
     if (!HasValidSerial()) {
         throw ZerocoinException("Invalid serial # range");

--- a/src/sigma/coinspend.h
+++ b/src/sigma/coinspend.h
@@ -17,7 +17,7 @@ public:
     CoinSpend(const Params* p,  Stream& strm):
         params(p),
         denomination(CoinDenomination::SIGMA_DENOM_1),
-        sigmaProof(p) {
+        sigmaProof(p->get_n(), p->get_m()) {
             strm >> * this;
         }
 
@@ -70,7 +70,7 @@ public:
         READWRITE(ecdsaPubkey);
         READWRITE(ecdsaSignature);
     }
-    
+
     uint256 signatureHash(const SpendMetaData& m) const;
 
 private:

--- a/src/sigma/sigmaplus_proof.h
+++ b/src/sigma/sigmaplus_proof.h
@@ -9,12 +9,12 @@ namespace sigma {
 template<class Exponent, class GroupElement>
 class SigmaPlusProof {
 public:
-    SigmaPlusProof(const Params* p): params(p) {};
+    SigmaPlusProof(int n, int m): n(n), m(m) {};
 
     inline int memoryRequired() const {
         return B_.memoryRequired()
-               + r1Proof_.memoryRequired(params->get_n(), params->get_m())
-               + B_.memoryRequired() * params->get_m()
+               + r1Proof_.memoryRequired(n, m)
+               + B_.memoryRequired() * m
                + z_.memoryRequired();
     }
 
@@ -28,9 +28,9 @@ public:
 
     inline unsigned char* deserialize(unsigned char* buffer) {
         unsigned char* current = B_.deserialize(buffer);
-        current = r1Proof_.deserialize(current, params->get_n(), params->get_m());
-        Gk_.resize(params->get_m());
-        for(int i = 0; i < params->get_m(); ++i)
+        current = r1Proof_.deserialize(current, n, m);
+        Gk_.resize(m);
+        for(int i = 0; i < m; ++i)
             current = Gk_[i].deserialize(current);
         return z_.deserialize(current);
     }
@@ -45,7 +45,8 @@ public:
     }
 
 public:
-    const Params* params;
+    int n;
+    int m;
     GroupElement B_;
     R1Proof<Exponent, GroupElement> r1Proof_;
     std::vector<GroupElement> Gk_;

--- a/src/sigma/test/protocol_tests.cpp
+++ b/src/sigma/test/protocol_tests.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(one_out_of_n)
             commits[i].randomize();
         }
     }
-    sigma::SigmaPlusProof<secp_primitives::Scalar,secp_primitives::GroupElement> proof(params);
+    sigma::SigmaPlusProof<secp_primitives::Scalar,secp_primitives::GroupElement> proof(n, m);
 
     prover.proof(commits, index, r, proof);
 
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(prove_and_verify_in_different_set)
         }
     }
 
-    sigma::SigmaPlusProof<secp_primitives::Scalar,secp_primitives::GroupElement> proof(params);
+    sigma::SigmaPlusProof<secp_primitives::Scalar,secp_primitives::GroupElement> proof(n, m);
 
     prover.proof(commits, index, r, proof);
 
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(prove_coin_out_of_index)
         commits[i].randomize();
     }
 
-    sigma::SigmaPlusProof<secp_primitives::Scalar,secp_primitives::GroupElement> proof(params);
+    sigma::SigmaPlusProof<secp_primitives::Scalar,secp_primitives::GroupElement> proof(n, m);
 
     prover.proof(commits, commits.size(), r, proof);
 
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(prove_coin_not_in_set)
         commits[i].randomize();
     }
 
-    sigma::SigmaPlusProof<secp_primitives::Scalar,secp_primitives::GroupElement> proof(params);
+    sigma::SigmaPlusProof<secp_primitives::Scalar,secp_primitives::GroupElement> proof(n, m);
 
     prover.proof(commits, index, r, proof);
 

--- a/src/sigma/test/serialize_test.cpp
+++ b/src/sigma/test/serialize_test.cpp
@@ -74,13 +74,13 @@ BOOST_AUTO_TEST_CASE(proof_serialize)
         }
     }
 
-    sigma::SigmaPlusProof<secp_primitives::Scalar,secp_primitives::GroupElement> initial_proof(params);
+    sigma::SigmaPlusProof<secp_primitives::Scalar,secp_primitives::GroupElement> initial_proof(n, m);
 
     prover.proof(commits, index, r, initial_proof);
 
     unsigned char buffer [initial_proof.memoryRequired()];
     initial_proof.serialize(buffer);
-    sigma::SigmaPlusProof<secp_primitives::Scalar,secp_primitives::GroupElement> resulted_proof(params);
+    sigma::SigmaPlusProof<secp_primitives::Scalar,secp_primitives::GroupElement> resulted_proof(n, m);
     resulted_proof.deserialize(buffer);
 
     BOOST_CHECK(initial_proof.B_ == resulted_proof.B_);


### PR DESCRIPTION
`Params` is application level specific then it should not be dependency of sigma plus proof class.