### PR TITLE
Update text for non-HD warning

### DIFF
--- a/src/qt/forms/blanksigmadialog.ui
+++ b/src/qt/forms/blanksigmadialog.ui
@@ -18,7 +18,7 @@
        <property name="text">
         <string>We have detected that your wallet does not use an HD seed. An HD seed allows you to restore all your private keys and also Sigma mints when restoring from a backup.
 
-To have Sigma private transactions functionality, an HD wallet is required. We highly recommend that you create a new wallet and send your funds over to the newly-created wallet or use the dumpwallet command in conjunction with importwallet to move your keys to the new wallet.
+To have Sigma private transactions functionality, an HD wallet is required. We highly recommend that you create a new wallet and send your funds over to the newly-created wallet or use the dumpwallet command in conjunction with importwallet to move your keys to the new wallet. If you have existing Zerocoins, they will be also ported following using dump/import wallet, and the Remint page will be accessible to you.
 </string>
        </property>
        <property name="alignment">


### PR DESCRIPTION
## PR intention
Fixes https://github.com/zcoinofficial/zcoin/issues/543

Update warning text for non-HD wallets at the Sigma page, to alert users that they can now dump and import Zerocoins as well as normal keys.
