### PR TITLE
HDMint Cleanup

### DIFF
--- a/src/hdmint/tracker.h
+++ b/src/hdmint/tracker.h
@@ -26,7 +26,7 @@ public:
     CHDMintTracker(std::string strWalletFile);
     ~CHDMintTracker();
     void Add(const CHDMint& dMint, bool isNew = false, bool isArchived = false);
-    void Add(const CSigmaEntry& zerocoin, bool isNew = false, bool isArchived = false);
+    void Add(const CSigmaEntry& sigma, bool isNew = false, bool isArchived = false);
     bool Archive(CMintMeta& meta);
     bool HasPubcoinHash(const uint256& hashPubcoin) const;
     bool HasSerialHash(const uint256& hashSerial) const;
@@ -44,7 +44,7 @@ public:
     void UpdateSpendStateFromBlock(const sigma::spend_info_container& spentSerials);
     void UpdateMintStateFromMempool(const std::vector<GroupElement>& pubCoins);
     void UpdateSpendStateFromMempool(const vector<Scalar>& spentSerials);
-    list<CSigmaEntry> MintsAsZerocoinEntries(bool fUnusedOnly = true, bool fMatureOnly = true);
+    list<CSigmaEntry> MintsAsSigmaEntries(bool fUnusedOnly = true, bool fMatureOnly = true);
     std::vector<CMintMeta> ListMints(bool fUnusedOnly = true, bool fMatureOnly = true, bool fUpdateStatus = true, bool fLoad = false, bool fWrongSeed = false);
     void RemovePending(const uint256& txid);
     void SetPubcoinUsed(const uint256& hashPubcoin, const uint256& txid);

--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -52,12 +52,12 @@ bool CHDMintWallet::SetupWallet(const uint160& hashSeedMaster, bool fResetCount)
     nCountNextGenerate = COUNT_DEFAULT;
 
     if (fResetCount){
-        walletdb.WriteZerocoinCount(nCountNextUse);
-        walletdb.WriteZerocoinSeedCount(nCountNextGenerate);
+        walletdb.WriteMintCount(nCountNextUse);
+        walletdb.WriteMintSeedCount(nCountNextGenerate);
     }else{
-        if (!walletdb.ReadZerocoinCount(nCountNextUse))
+        if (!walletdb.ReadMintCount(nCountNextUse))
             nCountNextUse = COUNT_DEFAULT;
-        if (!walletdb.ReadZerocoinSeedCount(nCountNextGenerate))
+        if (!walletdb.ReadMintSeedCount(nCountNextGenerate))
             nCountNextGenerate = COUNT_DEFAULT;
     }
 
@@ -75,14 +75,14 @@ std::pair<uint256,uint256> CHDMintWallet::RegenerateMintPoolEntry(const uint160&
     if (pwalletMain->IsLocked())
         throw ZerocoinException("Error: Please enter the wallet passphrase with walletpassphrase first.");
 
-    uint512 seedZerocoin;
-    if(!CreateZerocoinSeed(seedZerocoin, nCount, seedId, false))
+    uint512 mintSeed;
+    if(!CreateMintSeed(mintSeed, nCount, seedId, false))
         throw ZerocoinException("Unable to create seed for mint regeneration.");
 
     GroupElement commitmentValue;
     sigma::PrivateCoin coin(sigma::Params::get_default(), sigma::CoinDenomination::SIGMA_DENOM_1);
-    if(!SeedToZerocoin(seedZerocoin, commitmentValue, coin))
-        throw ZerocoinException("Unable to create zerocoin from seed in mint regeneration.");
+    if(!SeedToMint(mintSeed, commitmentValue, coin))
+        throw ZerocoinException("Unable to create sigmamint from seed in mint regeneration.");
 
     uint256 hashPubcoin = primitives::GetPubCoinValueHash(commitmentValue);
     uint256 hashSerial = primitives::GetSerialHash(coin.getSerialNumber());
@@ -123,13 +123,13 @@ void CHDMintWallet::GenerateMintPool(int32_t nIndex)
             return;
 
         CKeyID seedId;
-        uint512 seedZerocoin;
-        if(!CreateZerocoinSeed(seedZerocoin, nLastCount, seedId))
+        uint512 mintSeed;
+        if(!CreateMintSeed(mintSeed, nLastCount, seedId))
             continue;
 
         GroupElement commitmentValue;
         sigma::PrivateCoin coin(sigma::Params::get_default(), sigma::CoinDenomination::SIGMA_DENOM_1);
-        if(!SeedToZerocoin(seedZerocoin, commitmentValue, coin))
+        if(!SeedToMint(mintSeed, commitmentValue, coin))
             continue;
 
         uint256 hashPubcoin = primitives::GetPubCoinValueHash(commitmentValue);
@@ -143,7 +143,7 @@ void CHDMintWallet::GenerateMintPool(int32_t nIndex)
 
     // Update local + DB entries for count last generated
     nCountNextGenerate = nLastCount;
-    walletdb.WriteZerocoinSeedCount(nCountNextGenerate);
+    walletdb.WriteMintSeedCount(nCountNextGenerate);
 
 }
 
@@ -295,10 +295,10 @@ bool CHDMintWallet::SetMintSeedSeen(std::pair<uint256,MintPoolEntry> mintPoolEnt
     bool serialInBlockchain = false;
     // Can regenerate if unlocked (cheaper)
     if(!pwalletMain->IsLocked()){
-        uint512 seedZerocoin;
-        CreateZerocoinSeed(seedZerocoin, mintCount, seedId, false);
+        uint512 mintSeed;
+        CreateMintSeed(mintSeed, mintCount, seedId, false);
         sigma::PrivateCoin coin(sigma::Params::get_default(), denom, false);
-        if(!SeedToZerocoin(seedZerocoin, bnValue, coin))
+        if(!SeedToMint(mintSeed, bnValue, coin))
             return false;
         hashSerial = primitives::GetSerialHash(coin.getSerialNumber());
     }else{
@@ -350,10 +350,10 @@ bool CHDMintWallet::SetMintSeedSeen(std::pair<uint256,MintPoolEntry> mintPoolEnt
     return true;
 }
 
-bool CHDMintWallet::SeedToZerocoin(const uint512& seedZerocoin, GroupElement& commit, sigma::PrivateCoin& coin)
+bool CHDMintWallet::SeedToMint(const uint512& mintSeed, GroupElement& commit, sigma::PrivateCoin& coin)
 {
     //convert state seed into a seed for the private key
-    uint256 nSeedPrivKey = seedZerocoin.trim256();
+    uint256 nSeedPrivKey = mintSeed.trim256();
     nSeedPrivKey = Hash(nSeedPrivKey.begin(), nSeedPrivKey.end());
     coin.setEcdsaSeckey(nSeedPrivKey);
 
@@ -366,9 +366,9 @@ bool CHDMintWallet::SeedToZerocoin(const uint512& seedZerocoin, GroupElement& co
     Scalar serialNumber = coin.serialNumberFromSerializedPublicKey(OpenSSLContext::get_context(), &pubkey);
     coin.setSerialNumber(serialNumber);
 
-    //hash randomness seed with Bottom 256 bits of seedZerocoin
+    //hash randomness seed with Bottom 256 bits of mintSeed
     Scalar randomness;
-    uint256 nSeedRandomness = ArithToUint512(UintToArith512(seedZerocoin) >> 256).trim256();
+    uint256 nSeedRandomness = ArithToUint512(UintToArith512(mintSeed) >> 256).trim256();
     randomness.memberFromSeed(nSeedRandomness.begin());
     coin.setRandomness(randomness);
 
@@ -379,7 +379,7 @@ bool CHDMintWallet::SeedToZerocoin(const uint512& seedZerocoin, GroupElement& co
     return true;
 }
 
-CKeyID CHDMintWallet::GetZerocoinSeedID(int32_t nCount){
+CKeyID CHDMintWallet::GetMintSeedID(int32_t nCount){
     // Get CKeyID for n from mintpool
     uint256 hashPubcoin;
     std::pair<uint256,MintPoolEntry> mintPoolEntryPair;
@@ -396,7 +396,7 @@ CKeyID CHDMintWallet::GetZerocoinSeedID(int32_t nCount){
     return get<1>(mintPoolEntryPair.second);
 }
 
-bool CHDMintWallet::CreateZerocoinSeed(uint512& seedZerocoin, const int32_t& n, CKeyID& seedId, bool checkIndex)
+bool CHDMintWallet::CreateMintSeed(uint512& mintSeed, const int32_t& n, CKeyID& seedId, bool checkIndex)
 {
     LOCK(pwalletMain->cs_wallet);
     CKey key;
@@ -429,7 +429,7 @@ bool CHDMintWallet::CreateZerocoinSeed(uint512& seedZerocoin, const int32_t& n, 
 
     CHMAC_SHA512(countHash, CSHA256().OUTPUT_SIZE).Write(key.begin(), key.size()).Finalize(&result[0]);
 
-    seedZerocoin = uint512(result);
+    mintSeed = uint512(result);
 
     return true;
 }
@@ -442,7 +442,7 @@ int32_t CHDMintWallet::GetCount()
 void CHDMintWallet::ResetCount()
 {
     CWalletDB walletdb(strWalletFile);
-    walletdb.ReadZerocoinCount(nCountNextUse);
+    walletdb.WriteMintCount(nCountNextUse);
 }
 
 void CHDMintWallet::SetCount(int32_t nCount)
@@ -460,7 +460,7 @@ void CHDMintWallet::UpdateCountDB()
 {
     LogPrintf("CHDMintWallet : Updating count in DB to %s\n",nCountNextUse);	
     CWalletDB walletdb(strWalletFile);
-    walletdb.WriteZerocoinCount(nCountNextUse);
+    walletdb.WriteMintCount(nCountNextUse);
     GenerateMintPool();
 }
 
@@ -475,7 +475,7 @@ bool CHDMintWallet::GenerateMint(const sigma::CoinDenomination denom, sigma::Pri
     if(mintPoolEntry==boost::none){
         if(hashSeedMaster.IsNull())
             throw ZerocoinException("Unable to generate mint: HashSeedMaster not set");
-        CKeyID seedId = GetZerocoinSeedID(nCountNextUse);
+        CKeyID seedId = GetMintSeedID(nCountNextUse);
         mintPoolEntry = MintPoolEntry(hashSeedMaster, seedId, nCountNextUse);
         // Empty mintPoolEntry implies this is a new mint being created, so update nCountNextUse
         UpdateCountLocal();
@@ -484,11 +484,11 @@ bool CHDMintWallet::GenerateMint(const sigma::CoinDenomination denom, sigma::Pri
     LogPrintf("GenerateMint: hashSeedMaster: %s seedId: %s nCount: %d\n", 
              get<0>(mintPoolEntry.get()).GetHex(), get<1>(mintPoolEntry.get()).GetHex(), get<2>(mintPoolEntry.get()));
 
-    uint512 seedZerocoin;
-    CreateZerocoinSeed(seedZerocoin, get<2>(mintPoolEntry.get()), get<1>(mintPoolEntry.get()), false);
+    uint512 mintSeed;
+    CreateMintSeed(mintSeed, get<2>(mintPoolEntry.get()), get<1>(mintPoolEntry.get()), false);
 
     GroupElement commitmentValue;
-    if(!SeedToZerocoin(seedZerocoin, commitmentValue, coin)){
+    if(!SeedToMint(mintSeed, commitmentValue, coin)){
         return false;
     }
 
@@ -502,7 +502,7 @@ bool CHDMintWallet::GenerateMint(const sigma::CoinDenomination denom, sigma::Pri
     return true;
 }
 
-bool CHDMintWallet::RegenerateMint(const CHDMint& dMint, CSigmaEntry& zerocoin)
+bool CHDMintWallet::RegenerateMint(const CHDMint& dMint, CSigmaEntry& sigma)
 {
     //Generate the coin
     sigma::PrivateCoin coin(sigma::Params::get_default(), dMint.GetDenomination().get(), false);
@@ -512,23 +512,23 @@ bool CHDMintWallet::RegenerateMint(const CHDMint& dMint, CSigmaEntry& zerocoin)
     MintPoolEntry mintPoolEntry(hashSeedMaster, seedId, nCount);
     GenerateMint(dMint.GetDenomination().get(), coin, dMintDummy, mintPoolEntry);
 
-    //Fill in the zerocoinmint object's details
+    //Fill in the sigmamint object's details
     GroupElement bnValue = coin.getPublicCoin().getValue();
     if (primitives::GetPubCoinValueHash(bnValue) != dMint.GetPubCoinHash())
         return error("%s: failed to correctly generate mint, pubcoin hash mismatch", __func__);
-    zerocoin.value = bnValue;
+    sigma.value = bnValue;
 
     Scalar bnSerial = coin.getSerialNumber();
     if (primitives::GetSerialHash(bnSerial) != dMint.GetSerialHash())
         return error("%s: failed to correctly generate mint, serial hash mismatch", __func__);
 
-    zerocoin.set_denomination(dMint.GetDenomination().get());
-    zerocoin.randomness = coin.getRandomness();
-    zerocoin.serialNumber = bnSerial;
-    zerocoin.IsUsed = dMint.IsUsed();
-    zerocoin.nHeight = dMint.GetHeight();
-    zerocoin.id = dMint.GetId();
-    zerocoin.ecdsaSecretKey = std::vector<unsigned char>(&coin.getEcdsaSeckey()[0],&coin.getEcdsaSeckey()[32]);
+    sigma.set_denomination(dMint.GetDenomination().get());
+    sigma.randomness = coin.getRandomness();
+    sigma.serialNumber = bnSerial;
+    sigma.IsUsed = dMint.IsUsed();
+    sigma.nHeight = dMint.GetHeight();
+    sigma.id = dMint.GetId();
+    sigma.ecdsaSecretKey = std::vector<unsigned char>(&coin.getEcdsaSeckey()[0],&coin.getEcdsaSeckey()[32]);
 
     return true;
 }
@@ -552,19 +552,19 @@ bool CHDMintWallet::IsSerialInBlockchain(const uint256& hashSerial, int& nHeight
 bool CHDMintWallet::TxOutToPublicCoin(const CTxOut& txout, sigma::PublicCoin& pubCoin, CValidationState& state)
 {
     // If you wonder why +1, go to file wallet.cpp and read the comments in function
-    // CWallet::CreateZerocoinMintModelV3 around "scriptSerializedCoin << OP_ZEROCOINMINTV3";
+    // CWallet::CreateSigmaMintModel around "scriptSerializedCoin << OP_SIGMAMINT";
     vector<unsigned char> coin_serialised(txout.scriptPubKey.begin() + 1,
                                           txout.scriptPubKey.end());
-    secp_primitives::GroupElement publicZerocoin;
-    publicZerocoin.deserialize(&coin_serialised[0]);
+    secp_primitives::GroupElement publicSigma;
+    publicSigma.deserialize(&coin_serialised[0]);
 
     sigma::CoinDenomination denomination;
     if(!IntegerToDenomination(txout.nValue, denomination))
         return state.DoS(100, error("TxOutToPublicCoin : txout.nValue is not correct"));
 
-    LogPrint("zero", "%s ZCPRINT denomination %d pubcoin %s\n", __func__, denomination, publicZerocoin.GetHex());
+    LogPrint("zero", "%s ZCPRINT denomination %d pubcoin %s\n", __func__, denomination, publicSigma.GetHex());
 
-    sigma::PublicCoin checkPubCoin(publicZerocoin, denomination);
+    sigma::PublicCoin checkPubCoin(publicSigma, denomination);
     pubCoin = checkPubCoin;
 
     return true;

--- a/src/hdmint/wallet.h
+++ b/src/hdmint/wallet.h
@@ -34,14 +34,14 @@ public:
     void SyncWithChain(bool fGenerateMintPool = true, boost::optional<std::list<std::pair<uint256, MintPoolEntry>>> listMints = boost::none);
     bool GenerateMint(const sigma::CoinDenomination denom, sigma::PrivateCoin& coin, CHDMint& dMint, boost::optional<MintPoolEntry> mintPoolEntry = boost::none);
     bool LoadMintPoolFromDB();
-    bool RegenerateMint(const CHDMint& dMint, CSigmaEntry& zerocoin);
+    bool RegenerateMint(const CHDMint& dMint, CSigmaEntry& sigma);
     bool GetSerialForPubcoin(const std::vector<std::pair<uint256, GroupElement>>& serialPubcoinPairs, const uint256& hashPubcoin, uint256& hashSerial);
     bool IsSerialInBlockchain(const uint256& hashSerial, int& nHeightTx, uint256& txidSpend, CTransaction& tx);
     bool TxOutToPublicCoin(const CTxOut& txout, sigma::PublicCoin& pubCoin, CValidationState& state);
     std::pair<uint256,uint256> RegenerateMintPoolEntry(const uint160& mintHashSeedMaster, CKeyID& seedId, const int32_t& nCount);
     void GenerateMintPool(int32_t nIndex = 0);
     bool SetMintSeedSeen(std::pair<uint256,MintPoolEntry> mintPoolEntryPair, const int& nHeight, const uint256& txid, const sigma::CoinDenomination& denom);
-    bool SeedToZerocoin(const uint512& seedZerocoin, GroupElement& bnValue, sigma::PrivateCoin& coin);
+    bool SeedToMint(const uint512& mintSeed, GroupElement& bnValue, sigma::PrivateCoin& coin);
     // Count updating functions
     int32_t GetCount();
     CHDMintTracker& GetTracker() { return tracker; }
@@ -52,8 +52,8 @@ public:
     void UpdateCount();
 
 private:
-    CKeyID GetZerocoinSeedID(int32_t nCount);
-    bool CreateZerocoinSeed(uint512& seedZerocoin, const int32_t& n, CKeyID& seedId, bool checkIndex=true);
+    CKeyID GetMintSeedID(int32_t nCount);
+    bool CreateMintSeed(uint512& mintSeed, const int32_t& n, CKeyID& seedId, bool checkIndex=true);
 };
 
 #endif //ZCOIN_HDMINTWALLET_H

--- a/src/qt/forms/blanksigmadialog.ui
+++ b/src/qt/forms/blanksigmadialog.ui
@@ -18,7 +18,7 @@
        <property name="text">
         <string>We have detected that your wallet does not use an HD seed. An HD seed allows you to restore all your private keys and also Sigma mints when restoring from a backup.
 
-To have Sigma private transactions functionality, an HD wallet is required. We highly recommend that you create a new wallet and send your funds over to the newly-created wallet or use the dumpwallet command in conjunction with importwallet to move your keys to the new wallet.
+To have Sigma private transactions functionality, an HD wallet is required. We highly recommend that you create a new wallet and send your funds over to the newly-created wallet or use the dumpwallet command in conjunction with importwallet to move your keys to the new wallet. If you have existing Zerocoins, they will be also ported following using dump/import wallet, and the Remint page will be accessible to you.
 </string>
        </property>
        <property name="alignment">

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3511,7 +3511,7 @@ UniValue listsigmamints(const UniValue& params, bool fHelp) {
 
     list <CSigmaEntry> listPubcoin;
     CWalletDB walletdb(pwalletMain->strWalletFile);
-    listPubcoin = zwalletMain->GetTracker().MintsAsZerocoinEntries(false, false);
+    listPubcoin = zwalletMain->GetTracker().MintsAsSigmaEntries(false, false);
     UniValue results(UniValue::VARR);
 
     BOOST_FOREACH(const CSigmaEntry &zerocoinItem, listPubcoin) {
@@ -3597,7 +3597,7 @@ UniValue listsigmapubcoins(const UniValue& params, bool fHelp) {
 
     list<CSigmaEntry> listPubcoin;
     CWalletDB walletdb(pwalletMain->strWalletFile);
-    listPubcoin = zwalletMain->GetTracker().MintsAsZerocoinEntries(false, false);
+    listPubcoin = zwalletMain->GetTracker().MintsAsSigmaEntries(false, false);
     UniValue results(UniValue::VARR);
     listPubcoin.sort(CompSigmaHeight);
 

--- a/src/wallet/test/sigma_tests.cpp
+++ b/src/wallet/test/sigma_tests.cpp
@@ -56,7 +56,7 @@ static void AddSigmaCoin(const sigma::PrivateCoin& coin, const sigma::CoinDenomi
 
     std::copy_n(coin.getEcdsaSeckey(), 32, zerocoinTx.ecdsaSecretKey.begin());
 
-    if (!CWalletDB(pwalletMain->strWalletFile).WriteZerocoinEntry(zerocoinTx)) {
+    if (!CWalletDB(pwalletMain->strWalletFile).WriteSigmaEntry(zerocoinTx)) {
         throw std::runtime_error("Failed to add zerocoin to wallet");
     }
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2896,7 +2896,7 @@ void CWallet::ListAvailableSigmaMintCoins(vector<COutput> &vCoins, bool fOnlyCon
     LOCK2(cs_main, cs_wallet);
     list<CSigmaEntry> listOwnCoins;
     CWalletDB walletdb(pwalletMain->strWalletFile);
-    listOwnCoins = zwalletMain->GetTracker().MintsAsSigmaEntries();
+    listOwnCoins = zwalletMain->GetTracker().MintsAsSigmaEntries(true, false);
     LogPrintf("listOwnCoins.size()=%s\n", listOwnCoins.size());
     for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
         const CWalletTx *pcoin = &(*it).second;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2896,7 +2896,7 @@ void CWallet::ListAvailableSigmaMintCoins(vector<COutput> &vCoins, bool fOnlyCon
     LOCK2(cs_main, cs_wallet);
     list<CSigmaEntry> listOwnCoins;
     CWalletDB walletdb(pwalletMain->strWalletFile);
-    listOwnCoins = zwalletMain->GetTracker().MintsAsZerocoinEntries();
+    listOwnCoins = zwalletMain->GetTracker().MintsAsSigmaEntries();
     LogPrintf("listOwnCoins.size()=%s\n", listOwnCoins.size());
     for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
         const CWalletTx *pcoin = &(*it).second;
@@ -7032,7 +7032,7 @@ bool CWallet::GetMint(const uint256& hashSerial, CSigmaEntry& zerocoin) const
             return error("%s: failed to generate mint", __func__);
 
          return true;
-    } else if (!walletdb.ReadZerocoinEntry(meta.GetPubCoinValue(), zerocoin)) {
+    } else if (!walletdb.ReadSigmaEntry(meta.GetPubCoinValue(), zerocoin)) {
         return error("%s: failed to read zerocoinmint from database", __func__);
     }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -270,15 +270,15 @@ bool CWalletDB::WriteZerocoinEntry(const CZerocoinEntry &zerocoin) {
     return Write(make_pair(string("zerocoin"), zerocoin.value), zerocoin, true);
 }
 
-bool CWalletDB::WriteZerocoinEntry(const CSigmaEntry &zerocoin) {
-    return Write(std::make_pair(std::string("sigma_mint"), zerocoin.value), zerocoin, true);
+bool CWalletDB::WriteSigmaEntry(const CSigmaEntry &sigma) {
+    return Write(std::make_pair(std::string("sigma_mint"), sigma.value), sigma, true);
 }
 
 bool CWalletDB::ReadZerocoinEntry(const Bignum& pub, CZerocoinEntry& entry) {
     return Read(std::make_pair(std::string("zerocoin"), pub), entry);
 }
 
-bool CWalletDB::ReadZerocoinEntry(const secp_primitives::GroupElement& pub, CSigmaEntry& entry) {
+bool CWalletDB::ReadSigmaEntry(const secp_primitives::GroupElement& pub, CSigmaEntry& entry) {
     return Read(std::make_pair(std::string("sigma_mint"), pub), entry);
 }
 
@@ -286,12 +286,12 @@ bool CWalletDB::HasZerocoinEntry(const Bignum& pub) {
     return Exists(std::make_pair(std::string("zerocoin"), pub));
 }
 
-bool CWalletDB::HasZerocoinEntry(const secp_primitives::GroupElement& pub) {
+bool CWalletDB::HasSigmaEntry(const secp_primitives::GroupElement& pub) {
     return Exists(std::make_pair(std::string("sigma_mint"), pub));
 }
 
-bool CWalletDB::EraseZerocoinEntry(const CSigmaEntry &zerocoin) {
-    return Erase(std::make_pair(std::string("sigma_mint"), zerocoin.value));
+bool CWalletDB::EraseSigmaEntry(const CSigmaEntry &sigma) {
+    return Erase(std::make_pair(std::string("sigma_mint"), sigma.value));
 }
 
 bool CWalletDB::EraseZerocoinEntry(const CZerocoinEntry &zerocoin) {
@@ -1001,7 +1001,7 @@ DBErrors CWalletDB::ZapSigmaMints(CWallet *pwallet) {
     // erase each non HD Mint
     BOOST_FOREACH(CSigmaEntry & sigmaEntry, sigmaEntries)
     {
-        if (!EraseZerocoinEntry(sigmaEntry))
+        if (!EraseSigmaEntry(sigmaEntry))
             return DB_CORRUPT;
     }
 
@@ -1297,22 +1297,22 @@ bool CWalletDB::WriteHDChain(const CHDChain &chain) {
     return Write(std::string("hdchain"), chain);
 }
 
-bool CWalletDB::ReadZerocoinCount(int32_t& nCount)
+bool CWalletDB::ReadMintCount(int32_t& nCount)
 {
     return Read(string("dzc"), nCount);
 }
 
-bool CWalletDB::WriteZerocoinCount(const int32_t& nCount)
+bool CWalletDB::WriteMintCount(const int32_t& nCount)
 {
     return Write(string("dzc"), nCount);
 }
 
-bool CWalletDB::ReadZerocoinSeedCount(int32_t& nCount)
+bool CWalletDB::ReadMintSeedCount(int32_t& nCount)
 {
     return Read(string("dzsc"), nCount);
 }
 
-bool CWalletDB::WriteZerocoinSeedCount(const int32_t& nCount)
+bool CWalletDB::WriteMintSeedCount(const int32_t& nCount)
 {
     return Write(string("dzsc"), nCount);
 }
@@ -1543,15 +1543,15 @@ bool CWalletDB::UnarchiveHDMint(const uint256& hashPubcoin, CHDMint& dMint)
     return true;
 }
 
-bool CWalletDB::UnarchiveZerocoinMint(const uint256& hashPubcoin, CSigmaEntry& zerocoin)
+bool CWalletDB::UnarchiveSigmaMint(const uint256& hashPubcoin, CSigmaEntry& sigma)
 {
-    if (!Read(make_pair(string("zco"), hashPubcoin), zerocoin))
-        return error("%s: failed to retrieve zerocoinmint from archive", __func__);
+    if (!Read(make_pair(string("zco"), hashPubcoin), sigma))
+        return error("%s: failed to retrieve sigmamint from archive", __func__);
 
-    if (!WriteZerocoinEntry(zerocoin))
-        return error("%s: failed to write zerocoinmint", __func__);
+    if (!WriteSigmaEntry(sigma))
+        return error("%s: failed to write sigmamint", __func__);
 
-    uint256 hash = primitives::GetPubCoinValueHash(zerocoin.value);
+    uint256 hash = primitives::GetPubCoinValueHash(sigma.value);
     if (!Erase(make_pair(string("zco"), hash)))
         return error("%s : failed to erase archived zerocoin mint", __func__);
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -222,13 +222,13 @@ public:
     void ListAccountCreditDebit(const std::string& strAccount, std::list<CAccountingEntry>& acentries);
 
     bool WriteZerocoinEntry(const CZerocoinEntry& zerocoin);
-    bool WriteZerocoinEntry(const CSigmaEntry& zerocoin);
+    bool WriteSigmaEntry(const CSigmaEntry& zerocoin);
     bool ReadZerocoinEntry(const Bignum& pub, CZerocoinEntry& entry);
-    bool ReadZerocoinEntry(const secp_primitives::GroupElement& pub, CSigmaEntry& entry);
+    bool ReadSigmaEntry(const secp_primitives::GroupElement& pub, CSigmaEntry& entry);
     bool HasZerocoinEntry(const Bignum& pub);
-    bool HasZerocoinEntry(const secp_primitives::GroupElement& pub);
+    bool HasSigmaEntry(const secp_primitives::GroupElement& pub);
     bool EraseZerocoinEntry(const CZerocoinEntry& zerocoin);
-    bool EraseZerocoinEntry(const CSigmaEntry& zerocoin);
+    bool EraseSigmaEntry(const CSigmaEntry& sigma);
     void ListPubCoin(std::list<CZerocoinEntry>& listPubCoin);
     void ListSigmaPubCoin(std::list<CSigmaEntry>& listPubCoin);
     void ListCoinSpendSerial(std::list<CZerocoinSpendEntry>& listCoinSpendSerial);
@@ -255,15 +255,15 @@ public:
     static bool Recover(CDBEnv& dbenv, const std::string& filename, bool fOnlyKeys);
     static bool Recover(CDBEnv& dbenv, const std::string& filename);
 
-    bool ReadZerocoinCount(int32_t& nCount);
-    bool WriteZerocoinCount(const int32_t& nCount);
+    bool ReadMintCount(int32_t& nCount);
+    bool WriteMintCount(const int32_t& nCount);
 
-    bool ReadZerocoinSeedCount(int32_t& nCount);
-    bool WriteZerocoinSeedCount(const int32_t& nCount);
+    bool ReadMintSeedCount(int32_t& nCount);
+    bool WriteMintSeedCount(const int32_t& nCount);
 
     bool ArchiveMintOrphan(const CZerocoinEntry& zerocoin);
     bool ArchiveDeterministicOrphan(const CHDMint& dMint);
-    bool UnarchiveZerocoinMint(const uint256& hashPubcoin, CSigmaEntry& zerocoin);
+    bool UnarchiveSigmaMint(const uint256& hashPubcoin, CSigmaEntry& zerocoin);
     bool UnarchiveHDMint(const uint256& hashPubcoin, CHDMint& dMint);
 
     bool WriteHDMint(const CHDMint& dMint);


### PR DESCRIPTION
## PR intention
Cleanups and refactoring of some HDMint code.

## Code changes brief
- Renaming all Zerocoin to Sigma
- Add logging to `SetMintSeedSeen` function in `hdmint/tracker.cpp`
- Consider non-mature mints (ie. mints with <6 confs) in `listunspentsigmamints`