### PR TITLE
Fix BIP44 keypool issue with older encrypted wallets

### DIFF
--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -205,9 +205,11 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn, const bool& fF
         vMasterKey = vMasterKeyIn;
         fDecryptionThoroughlyChecked = true;
         if(!fFirstUnlock && zwalletMain){
-            uint160 hashSeedMaster = pwalletMain->GetHDChain().masterKeyID;
+            CHDChain hdChain = pwalletMain->GetHDChain();
+            uint160 hashSeedMaster = hdChain.masterKeyID;
             zwalletMain->SetupWallet(hashSeedMaster, false);
             zwalletMain->SyncWithChain();
+            pwalletMain->SetHDChain(hdChain, false); // Used to upgrade normal keys to BIP44
         }
     }
     NotifyStatusChanged(this);

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -205,7 +205,7 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn, const bool& fF
         vMasterKey = vMasterKeyIn;
         fDecryptionThoroughlyChecked = true;
         if(!fFirstUnlock && zwalletMain){
-            CHDChain hdChain = pwalletMain->GetHDChain();
+            auto &hdChain = pwalletMain->GetHDChain();
             uint160 hashSeedMaster = hdChain.masterKeyID;
             zwalletMain->SetupWallet(hashSeedMaster, false);
             zwalletMain->SyncWithChain();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1396,11 +1396,10 @@ bool CWallet::SetHDMasterKey(const CPubKey &pubkey) {
 bool CWallet::SetHDChain(const CHDChain &chain, bool memonly) {
     LOCK(cs_wallet);
     bool upgradeChain = (chain.nVersion==CHDChain::VERSION_BASIC);
-    if(upgradeChain){ // Upgrade HDChain to latest version
+    if(upgradeChain && !IsLocked()){ // Upgrade HDChain to latest version
         CHDChain newChain;
         newChain.masterKeyID = chain.masterKeyID;
-        newChain.nExternalChainCounters[0] = chain.nExternalChainCounter;
-
+        NewKeyPool();
         if (!memonly && !CWalletDB(strWalletFile).WriteHDChain(newChain))
             throw runtime_error(std::string(__func__) + ": writing chain failed");
         hdChain = newChain;


### PR DESCRIPTION
## PR intention
- Encrypted wallets that existed before the upgrade to HDMint/BIP44 continue to use the old keypool until it is exhausted. That means that these wallets will not use keys along the BIP44 path until all the current keys are used. The intention of this PR is to generate a new keypool, consisting of BIP44 keys, following wallet unlock. 

- This issue does not affect keys used for minting, new wallets generated, or older unencrypted wallets.

-While not a critical issue (the existing keys are still of course valid and retrievable using the master seed), Given the upgrade to BIP39, it is important that the same keys are generated between third party wallets as well as our own.

## Code changes brief
- `SetHDChain` now called following wallet unlock
- If previous wallet version detected in this function, upgrade wallet, and generate new keypool.
- Also removes a line of code that sets the same index as previous; the index should reset to 0, as this is a new keypath.
