### PR TITLE
Enable all LGTM alerts

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,19 +1,27 @@
 path_classifiers:
   docs:
     - "exclude: /"
+    - "contrib"
+    - "share"
     - "ZNODE.md"
   generated:
     - "exclude: /"
+    - "src/obj"
     - "src/qt/moc_*.cpp"
   library:
     - "exclude: /"
+    - "src/leveldb"
+    - "src/libexecstream"
     - "src/tor"
   template:
     - "exclude: /"
     - "qa/pull-tester/run-bitcoind-for-test.sh.in"
+    - "src/qt/forms"
   test:
     - "exclude: /"
-    - "src/test/*_tests.cpp"
+    - "src/**/*_tests.cpp"
+queries:
+  - include: "*"
 extraction:
   cpp:
     prepare:


### PR DESCRIPTION
Right now there are some alerts that turn off by default. This PR will turn on all alerts. Then we can choose to turn of a specific alert later.

Changes will not take effect until this PR is merged so we will not see new alerts in this PR.

First step to for #733.