### PR TITLE
Fixed the unspent index for remints of 50 XZC

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -553,16 +553,15 @@ void CDbIndexHelper::ConnectTransaction(CTransaction const & tx, int height, int
 {
     size_t no = 0;
     if(!tx.IsCoinBase() && !tx.IsZerocoinSpend() && !tx.IsSigmaSpend() && !tx.IsZerocoinRemint()) {
-        for (std::vector<CTxIn>::const_iterator iter = tx.vin.begin(); iter != tx.vin.end(); ++iter) {
-            CTxIn const & input = *iter;
+        for (CTxIn const & input : tx.vin) {
             handleInput(input, no++, tx.GetHash(), height, txNumber, view, addressIndex, addressUnspentIndex, spentIndex);
         }
     }
 
     if(tx.IsZerocoinRemint()) {
         CAmount remintValue = 0;
-        for (std::vector<CTxOut>::const_iterator iter_out = tx.vout.begin(); iter_out != tx.vout.end(); ++iter_out) {
-            remintValue += iter_out->nValue;
+        for (CTxOut const & out : tx.vout) {
+            remintValue += out.nValue;
         }
         if (tx.vin.size() != 1) {
            error("A Zerocoin to Sigma remint tx shoud have just 1 input");
@@ -576,8 +575,7 @@ void CDbIndexHelper::ConnectTransaction(CTransaction const & tx, int height, int
 
     no = 0;
     bool const txIsCoinBase = tx.IsCoinBase();
-    for (std::vector<CTxOut>::const_iterator iter = tx.vout.begin(); iter != tx.vout.end(); ++iter) {
-        CTxOut const & out = *iter;
+    for (CTxOut const & out : tx.vout) {
         handleOutput(out, no++, tx.GetHash(), height, txNumber, view, txIsCoinBase, addressIndex, addressUnspentIndex, spentIndex);
     }
 }
@@ -597,8 +595,8 @@ void CDbIndexHelper::DisconnectTransactionInputs(CTransaction const & tx, int he
 
     if(tx.IsZerocoinRemint()) {
         CAmount remintValue = 0;
-        for (std::vector<CTxOut>::const_iterator iter_out = tx.vout.begin(); iter_out != tx.vout.end(); ++iter_out) {
-            remintValue += iter_out->nValue;
+        for (CTxOut const & out : tx.vout) {
+            remintValue += out.nValue;
         }
         if (tx.vin.size() != 1) {
            error("A Zerocoin to Sigma remint tx shoud have just 1 input");
@@ -610,8 +608,7 @@ void CDbIndexHelper::DisconnectTransactionInputs(CTransaction const & tx, int he
     size_t no = 0;
 
     if(!tx.IsCoinBase() && !tx.IsZerocoinSpend() && !tx.IsSigmaSpend() && !tx.IsZerocoinRemint())
-        for (std::vector<CTxIn>::const_iterator iter = tx.vin.begin(); iter != tx.vin.end(); ++iter) {
-            CTxIn const & input = *iter;
+        for (CTxIn const & input : tx.vin) {
             handleInput(input, no++, tx.GetHash(), height, txNumber, view, addressIndex, addressUnspentIndex, spentIndex);
         }
 
@@ -634,8 +631,7 @@ void CDbIndexHelper::DisconnectTransactionOutputs(CTransaction const & tx, int h
 
     size_t no = 0;
     bool const txIsCoinBase = tx.IsCoinBase();
-    for (std::vector<CTxOut>::const_iterator iter = tx.vout.begin(); iter != tx.vout.end(); ++iter) {
-        CTxOut const & out = *iter;
+    for (CTxOut const & out : tx.vout) {
         handleOutput(out, no++, tx.GetHash(), height, txNumber, view, txIsCoinBase, addressIndex, addressUnspentIndex, spentIndex);
     }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -487,19 +487,19 @@ void handleInput(CTxIn const & input, size_t inputNo, uint256 const & txHash, in
         spentIndex->push_back(make_pair(CSpentIndexKey(input.prevout.hash, input.prevout.n), CSpentIndexValue(txHash, inputNo, height, prevout.nValue, addrType.first, addrType.second)));
 }
 
-void handleRemint(CTxIn const & input, size_t inputNo, uint256 const & txHash, int height, int txNumber, CAmount nValue,
+void handleRemint(CTxIn const & input, uint256 const & txHash, int height, int txNumber, CAmount nValue,
         AddressIndexPtr & addressIndex, AddressUnspentIndexPtr & addressUnspentIndex, SpentIndexPtr & spentIndex)
 {
     if(!input.IsZerocoinRemint())
         return;
 
     if (addressIndex) {
-        addressIndex->push_back(make_pair(CAddressIndexKey(AddressType::zerocoinRemint, uint160(), height, txNumber, txHash, inputNo, true), nValue * -1));
+        addressIndex->push_back(make_pair(CAddressIndexKey(AddressType::zerocoinRemint, uint160(), height, txNumber, txHash, 0, true), nValue * -1));
         addressUnspentIndex->push_back(make_pair(CAddressUnspentKey(AddressType::zerocoinRemint, uint160(), input.prevout.hash, input.prevout.n), CAddressUnspentValue()));
     }
 
     if (spentIndex)
-        spentIndex->push_back(make_pair(CSpentIndexKey(input.prevout.hash, input.prevout.n), CSpentIndexValue(txHash, inputNo, height, nValue, AddressType::zerocoinRemint, uint160())));
+        spentIndex->push_back(make_pair(CSpentIndexKey(input.prevout.hash, input.prevout.n), CSpentIndexValue(txHash, 0, height, nValue, AddressType::zerocoinRemint, uint160())));
 }
 
 
@@ -568,7 +568,7 @@ void CDbIndexHelper::ConnectTransaction(CTransaction const & tx, int height, int
            error("A Zerocoin to Sigma remint tx shoud have just 1 input");
            return;
         }
-        handleRemint(tx.vin[0], 0, tx.GetHash(), height, txNumber, remintValue, addressIndex, addressUnspentIndex, spentIndex);
+        handleRemint(tx.vin[0], tx.GetHash(), height, txNumber, remintValue, addressIndex, addressUnspentIndex, spentIndex);
     }
 
     if(tx.IsZerocoinSpend() || tx.IsSigmaSpend())
@@ -604,7 +604,7 @@ void CDbIndexHelper::DisconnectTransactionInputs(CTransaction const & tx, int he
            error("A Zerocoin to Sigma remint tx shoud have just 1 input");
            return;
         }
-        handleRemint(tx.vin[0], 0, tx.GetHash(), height, txNumber, remintValue, addressIndex, addressUnspentIndex, spentIndex);
+        handleRemint(tx.vin[0], tx.GetHash(), height, txNumber, remintValue, addressIndex, addressUnspentIndex, spentIndex);
     }
 
     size_t no = 0;


### PR DESCRIPTION
## PR intention
Fixes an issue with calculating balance of remint transactions in case of 50XZC remints, which produced 2 outputs of 25 XZC Sigma mints. 

## Code changes brief
Now all remint outputs are summed up and used as the amount for the input.