### PR TITLE
Record serial before update status

### DIFF
--- a/src/exodus/txprocessor.cpp
+++ b/src/exodus/txprocessor.cpp
@@ -184,8 +184,8 @@ int TxProcessor::ProcessSimpleSpend(const CMPTransaction& tx)
         return PKT_ERROR_SIGMA - 45;
     }
 
-    assert(update_tally_map(tx.getReceiver(), property, amount, BALANCE));
     sigmaDb->RecordSpendSerial(property, denomination, spend->serial, block, tx.getHash());
+    assert(update_tally_map(tx.getReceiver(), property, amount, BALANCE));
 
     return 0;
 }


### PR DESCRIPTION
Reorder logic in spend checking function because if fail to record serial to database then state should not be update.