### PR TITLE
Fix issue with failing GetAddressGroupings with Private Spends

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -7387,14 +7387,13 @@ set <set<CTxDestination>> CWallet::GetAddressGroupings() {
     {
         CWalletTx *pcoin = &walletEntry.second;
 
-        if (pcoin->vin.size() > 0) {
+        if (pcoin->vin.size() > 0 &&
+            !(pcoin->IsZerocoinSpend() || pcoin->IsSigmaSpend())) { /* Spends have no standard input */
             bool any_mine = false;
             // group all input addresses with each other
             BOOST_FOREACH(CTxIn txin, pcoin->vin)
             {
                 CTxDestination address;
-                if (txin.IsZerocoinSpend() || txin.IsSigmaSpend()) /* Spends have no standard input */
-                    continue;
                 if (!IsMine(txin)) /* If this input isn't mine, ignore it */
                     continue;
                 if (!ExtractDestination(mapWallet[txin.prevout.hash].vout[txin.prevout.n].scriptPubKey, address))

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -7388,7 +7388,7 @@ set <set<CTxDestination>> CWallet::GetAddressGroupings() {
         CWalletTx *pcoin = &walletEntry.second;
 
         if (pcoin->vin.size() > 0 &&
-            !(pcoin->IsZerocoinSpend() || pcoin->IsSigmaSpend())) { /* Spends have no standard input */
+            !(pcoin->IsZerocoinSpend() || pcoin->IsSigmaSpend() || pcoin->IsZerocoinRemint())) { /* Spends have no standard input */
             bool any_mine = false;
             // group all input addresses with each other
             BOOST_FOREACH(CTxIn txin, pcoin->vin)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -7393,6 +7393,8 @@ set <set<CTxDestination>> CWallet::GetAddressGroupings() {
             BOOST_FOREACH(CTxIn txin, pcoin->vin)
             {
                 CTxDestination address;
+                if (txin.IsZerocoinSpend() || txin.IsSigmaSpend()) /* Spends have no standard input */
+                    continue;
                 if (!IsMine(txin)) /* If this input isn't mine, ignore it */
                     continue;
                 if (!ExtractDestination(mapWallet[txin.prevout.hash].vout[txin.prevout.n].scriptPubKey, address))


### PR DESCRIPTION
Fixes https://github.com/zcoinofficial/zcoin/issues/723

## PR intention
`GetAddressGroupings()` in `wallet/wallet.cpp` is causing a segfault if the wallet contains Zerocoin or Sigma spends. The issue is it expects each input of the transaction it's looking at to be associated with an address, spend inputs are not.

## Code changes brief
Avoid the code block that deals with inputs entirely by checking if the overall tx is a spend. This is sufficient as spends cannot have non-spend inputs.
