### PR TITLE
Segfault fix for non-HD wallets

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -573,7 +573,7 @@ bool CWallet::IsSpent(const uint256 &hash, unsigned int n) const {
             }
 
             return data.IsUsed;
-        } else if (script.IsSigmaMint()) {
+        } else if (zwalletMain && script.IsSigmaMint()) {
             auto pub = sigma::ParseSigmaMintScript(script);
             uint256 hashPubcoin = primitives::GetPubCoinValueHash(pub);
             CMintMeta meta;


### PR DESCRIPTION
## PR intention
Fixes a bug where non-HD wallets, having received a mixed mint transaction (ie. contains outputs to the non-HD wallet) causes a segfault at the `IsSpent` function. Generating a Sigma transaction is blocked in every case, the wallet has to have received such a transaction.

## Code changes brief
Generally, any call to `GetTracker()` in `zwalletMain` first checks for the existence of `zwalletMain`. This wasn't happening in `IsSpent`. Simply add this check.
