### PR TITLE
Ban zcoin nodes with version < 0.13.8.2

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6387,12 +6387,17 @@ bool static ProcessMessage(CNode *pfrom, string strCommand,
         if (!vRecv.empty()) {
             vRecv >> LIMITED_STRING(pfrom->strSubVer, MAX_SUBVERSION_LENGTH);
             pfrom->cleanSubVer = SanitizeString(pfrom->strSubVer);
-            if (nHeight > chainparams.GetConsensus().nOldSigmaBanBlock && pfrom->cleanSubVer == "/Satoshi:0.13.8.1/") {
-                pfrom->PushMessage(NetMsgType::REJECT, strCommand, REJECT_OBSOLETE, "This version is banned from the network");
-                pfrom->fDisconnect = 1;
-                LOCK(cs_main);
-                Misbehaving(pfrom->GetId(), 100);
-                return false;
+            int parsedVersion[4];
+            if (sscanf(pfrom->cleanSubVer.c_str(), "/Satoshi:%2d.%2d.%2d.%2d/",
+                    &parsedVersion[0], &parsedVersion[1], &parsedVersion[2], &parsedVersion[3]) == 4) {
+                int peerClientVersion = parsedVersion[0]*1000000 + parsedVersion[1]*10000 + parsedVersion[2]*100 + parsedVersion[3];
+                if (peerClientVersion < MIN_ZCOIN_CLIENT_VERSION) {
+                    pfrom->PushMessage(NetMsgType::REJECT, strCommand, REJECT_OBSOLETE, "This version is banned from the network");
+                    pfrom->fDisconnect = 1;
+                    LOCK(cs_main);
+                    Misbehaving(pfrom->GetId(), 100);
+                    return false;
+                }
             }
         }
         if (!vRecv.empty()) {

--- a/src/version.h
+++ b/src/version.h
@@ -48,4 +48,7 @@ static const int SHORT_IDS_BLOCKS_VERSION = 90013;
 //! not banning for invalid compact blocks starts with this version
 static const int INVALID_CB_NO_BAN_VERSION = 90013;
 
+//! minimum version of official client to connect to
+static const int MIN_ZCOIN_CLIENT_VERSION = 130802; // 0.13.8.2
+
 #endif // BITCOIN_VERSION_H


### PR DESCRIPTION
## PR intention
Ban versions of zcoin client below 0.13.8.2

## Code changes brief
Parse standard client version string in form of /Satosh:0.x.y.z/ and drop connection with every legacy node