### PR TITLE
Fixing mingw build

### DIFF
--- a/src/exodus/sigmadb.cpp
+++ b/src/exodus/sigmadb.cpp
@@ -254,7 +254,7 @@ SigmaDatabase::SigmaDatabase(const boost::filesystem::path& path, bool wipe, uin
 {
     auto status = Open(path, wipe);
     if (!status.ok()) {
-        throw std::runtime_error("Failed to create " + path.native() + ": " + status.ToString());
+        throw std::runtime_error(std::string("Failed to create ") + path.native() + ": " + status.ToString());
     }
 
     this->groupSize = InitGroupSize(groupSize);

--- a/src/exodus/sigmadb.cpp
+++ b/src/exodus/sigmadb.cpp
@@ -254,7 +254,7 @@ SigmaDatabase::SigmaDatabase(const boost::filesystem::path& path, bool wipe, uin
 {
     auto status = Open(path, wipe);
     if (!status.ok()) {
-        throw std::runtime_error(std::string("Failed to create ") + path.native() + ": " + status.ToString());
+        throw std::runtime_error("Failed to create " + path.string() + ": " + status.ToString());
     }
 
     this->groupSize = InitGroupSize(groupSize);


### PR DESCRIPTION
## PR intention
Fixing a minor issue which mingw reports:

exodus/sigmadb.cpp: In constructor exodus::SigmaDatabase::SigmaDatabase(const boost::filesystem::path&, bool, uint16_t):
exodus/sigmadb.cpp:257:54: error: no match for operator+ (operand types are const char [18] and const string_type {aka const std::basic_string<wchar_t>})
         throw std::runtime_error("Failed to create " + path.native() + ": " + status.ToString());
