### PR TITLE
Allow mints to pass unsynced state on regtest, fix tests

### DIFF
--- a/qa/rpc-tests/exodus_sigma_reindex.py
+++ b/qa/rpc-tests/exodus_sigma_reindex.py
@@ -59,16 +59,12 @@ class ExodusSigmaReindexTest(ExodusTestFramework):
         connect_nodes(self.nodes[0], 1)
 
         sync_blocks(self.nodes)
-        self.nodes[0].generate(1)
 
         reindexed_confirmed_mints = self.nodes[0].exodus_listmints()
         self.compare_mints(confirmed_mints, reindexed_confirmed_mints)
 
         reindexed_unconfirmed_mints = self.nodes[0].exodus_listpendingmints()
         self.compare_mints(unconfirmed_mints, reindexed_unconfirmed_mints)
-
-        sync_blocks(self.nodes)
-        self.nodes[0].generate(1)
 
         # spend remaining mints
         self.nodes[0].exodus_sendspend(self.addrs[0], sigma_property, 0)

--- a/qa/rpc-tests/hdmint_mempool_zap.py
+++ b/qa/rpc-tests/hdmint_mempool_zap.py
@@ -63,7 +63,6 @@ class HDMintMempoolZapTest(BitcoinTestFramework):
         bitcoind_processes[0].wait()
 
         self.nodes[0] = start_node(0,self.options.tmpdir, configuration)
-        self.nodes[0].generate(1)
 
         # 8. check listunspentmints - should be as on step 5 (cause ["-zapwallettxes"] clean mempool)
         sigma_mints2 = self.nodes[0].listunspentsigmamints()
@@ -87,7 +86,6 @@ class HDMintMempoolZapTest(BitcoinTestFramework):
         assert len(sigma_mints3) == len(sigma_mints1), \
             'The amount of mints should be same as before unconfirmed spend after restart with ["-zapwallettxes"].'
 
-        self.nodes[0].generate(1)
         # 12. mint
         # Minting after restart with '-["-zapwallettxes"]'
         self.nodes[0].mint(sigma_denoms[0])

--- a/qa/rpc-tests/sigma_remint_lockedwallet.py
+++ b/qa/rpc-tests/sigma_remint_lockedwallet.py
@@ -65,8 +65,6 @@ class SigmaRemintLockedWalletTest(BitcoinTestFramework):
         self.nodes[0].walletpassphrase(encr_key, 10)
         time.sleep(5)
         
-        self.nodes[0].generate(1)
-
         # remint should work
         self.nodes[0].remintzerocointosigma(zcoin_denoms[0])
 

--- a/qa/rpc-tests/sigma_zapwalletmints.py
+++ b/qa/rpc-tests/sigma_zapwalletmints.py
@@ -53,8 +53,6 @@ class SigmaZapWalletMintsTest(BitcoinTestFramework):
         assert len(sigma_mints2) == len(sigma_mints1), \
             'The amount of mints should be same after restart with zapwalletmints.'
 
-        self.nodes[0].generate(1)
-        self.sync_all()
         # Minting after restart with '-zapwalletmints'
         self.nodes[0].mint(sigma_denoms[0])
 

--- a/qa/rpc-tests/sigma_zapwalletmints_unconf_trans.py
+++ b/qa/rpc-tests/sigma_zapwalletmints_unconf_trans.py
@@ -69,15 +69,11 @@ class SigmaZapWalletMintsUnconfirmedTest(BitcoinTestFramework):
         while self.nodes[0].getinfo()["blocks"] != last_block_height:
             time.sleep(1)
 
-        self.nodes[0].generate(1)
-
         # 8. check listunspentmints - should be as on step 5 (cause ["-zapwalletmints"] clean mempool)
         sigma_mints2 = self.nodes[0].listunspentsigmamints()
 
         assert len(sigma_mints2) == len(sigma_mints1), \
             'The amount of mints should be same as before unconfirmed mint after restart with ["-zapwalletmints"].'
-
-        self.nodes[0].generate(1)
 
         val = {'THAYjKnnCsN5xspnEcb1Ztvw4mSPBuwxzU': 1}
         # 9. spend and not confirm
@@ -92,8 +88,6 @@ class SigmaZapWalletMintsUnconfirmedTest(BitcoinTestFramework):
         while self.nodes[0].getinfo()["blocks"] != last_block_height:
             time.sleep(1)        
 
-        self.nodes[0].generate(1)
-
         # 11. check listunspentmints - should be as on step 5 (cause ["-zapwalletmints"] clean mempool)
         sigma_mints3 = self.nodes[0].listunspentsigmamints()
 
@@ -102,7 +96,6 @@ class SigmaZapWalletMintsUnconfirmedTest(BitcoinTestFramework):
 
         # 12. mint
         # Minting after restart with '-["-zapwalletmints"]'
-        self.nodes[0].generate(1)
         self.nodes[0].mint(sigma_denoms[0])
 
         # 13. generate blocks

--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -500,7 +500,7 @@ bool CHDMintWallet::GetHDMintFromMintPoolEntry(const sigma::CoinDenomination den
 
 bool CHDMintWallet::GenerateMint(const sigma::CoinDenomination denom, sigma::PrivateCoin& coin, CHDMint& dMint, boost::optional<MintPoolEntry> mintPoolEntry, bool fAllowUnsynced)
 {
-    if(!znodeSync.IsBlockchainSynced() && !fAllowUnsynced)
+    if(!znodeSync.IsBlockchainSynced() && !fAllowUnsynced && !(Params().NetworkIDString() == CBaseChainParams::REGTEST))
         throw ZerocoinException("Unable to generate mint: Blockchain not yet synced.");
 
     if(mintPoolEntry!=boost::none)


### PR DESCRIPTION
## PR intention
~~Fixes a race condition in the rpc test `sigma_zapwalletmints_unconf_trans.py`. 
Since https://github.com/zcoinofficial/zcoin/pull/741 minting requires chain sync.  Following generation of a new block, a mint was immediately being done without waiting for chain sync.~~

### EDIT
`znodeSync.IsBlockchainSynced()` is used to check if chain is synced when creating a mint. This function works in an inconsistent way on regtest (and therefore, the RPC tests). So we instead allow mints to pass through if this function does not return `true` on regtest, and revert the previous changes to tests.
