### PR TITLE
Update Dockerfile for clientapi PR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update && apt-get install -y \
     make \
     openjdk-8-jdk \
     pkg-config \
-    zlib1g-dev
+    zlib1g-dev \
+    libminizip-dev
 
 # Install Berkeley DB 4.8
 RUN curl -L http://download.oracle.com/berkeley-db/db-4.8.30.tar.gz | tar -xz -C /tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN apt-get update && apt-get install -y \
     make \
     openjdk-8-jdk \
     pkg-config \
-    zlib1g-dev \
-    libminizip-dev
+    zlib1g-dev
 
 # Install Berkeley DB 4.8
 RUN curl -L http://download.oracle.com/berkeley-db/db-4.8.30.tar.gz | tar -xz -C /tmp && \

--- a/contrib/docker/builder/Dockerfile
+++ b/contrib/docker/builder/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     autoconf automake bsdmainutils ccache cmake curl g++ g++-mingw-w64-x86-64 gcc gcc-mingw-w64-x86-64 git \
     libboost-all-dev libbz2-dev libcap-dev libdb4.8-dev libdb4.8++-dev libevent-dev libminiupnpc-dev libprotobuf-dev \
     libqrencode-dev libssl-dev libtool libzmq3-dev make pkg-config protobuf-compiler python-pip qtbase5-dev \
-    qttools5-dev-tools python3-zmq
+    qttools5-dev-tools python3-zmq minizip
 
 RUN pip install ez_setup
 

--- a/contrib/docker/builder/Dockerfile
+++ b/contrib/docker/builder/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     autoconf automake bsdmainutils ccache cmake curl g++ g++-mingw-w64-x86-64 gcc gcc-mingw-w64-x86-64 git \
     libboost-all-dev libbz2-dev libcap-dev libdb4.8-dev libdb4.8++-dev libevent-dev libminiupnpc-dev libprotobuf-dev \
     libqrencode-dev libssl-dev libtool libzmq3-dev make pkg-config protobuf-compiler python-pip qtbase5-dev \
-    qttools5-dev-tools python3-zmq libminizip-dev
+    qttools5-dev-tools python3-zmq minizip
 
 RUN pip install ez_setup
 

--- a/contrib/docker/builder/Dockerfile
+++ b/contrib/docker/builder/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     autoconf automake bsdmainutils ccache cmake curl g++ g++-mingw-w64-x86-64 gcc gcc-mingw-w64-x86-64 git \
     libboost-all-dev libbz2-dev libcap-dev libdb4.8-dev libdb4.8++-dev libevent-dev libminiupnpc-dev libprotobuf-dev \
     libqrencode-dev libssl-dev libtool libzmq3-dev make pkg-config protobuf-compiler python-pip qtbase5-dev \
-    qttools5-dev-tools python3-zmq minizip
+    qttools5-dev-tools python3-zmq
 
 RUN pip install ez_setup
 

--- a/contrib/docker/builder/Dockerfile
+++ b/contrib/docker/builder/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     autoconf automake bsdmainutils ccache cmake curl g++ g++-mingw-w64-x86-64 gcc gcc-mingw-w64-x86-64 git \
     libboost-all-dev libbz2-dev libcap-dev libdb4.8-dev libdb4.8++-dev libevent-dev libminiupnpc-dev libprotobuf-dev \
     libqrencode-dev libssl-dev libtool libzmq3-dev make pkg-config protobuf-compiler python-pip qtbase5-dev \
-    qttools5-dev-tools python3-zmq
+    qttools5-dev-tools python3-zmq libminizip-dev
 
 RUN pip install ez_setup
 


### PR DESCRIPTION
## PR intention
The clientapi PR will add the need for one more dependancy, `libminizip-dev`. The Jenkins file for CI pulls from the remote Docker image and does not use the local one. So this PR adds the dependancy to the main dockerfile so that CI can pass on `clientapi`.

An alternative solution is to get the Jenkins file to pull from the Dockerfile of the branch, though as it's a rare occurrence that it changes this way is probably ok.

(It should also be noted that the dependancy is only needed if the configure option `--enable-clientapi` is set).