### PR TITLE
Mnemonic updates

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -617,8 +617,10 @@ int main(int argc, char *argv[])
     }
 #ifdef ENABLE_WALLET
     ///Determine if user wants to create new wallet or recover existing one
-    if(!Recover::askRecover(newWallet))
-        return EXIT_SUCCESS;
+    if(GetBoolArg("-usemnemonic", DEFAULT_USE_MNEMONIC)){
+        if(!Recover::askRecover(newWallet))
+            return EXIT_SUCCESS;
+    }
 
     // Parse URIs on command line -- this can affect Params()
     PaymentServer::ipcParseCommandLine(argc, argv);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -75,6 +75,9 @@ static const bool DEFAULT_WALLETBROADCAST = true;
 //! if set, all keys will be derived by using BIP32
 static const bool DEFAULT_USE_HD_WALLET = true;
 
+//! if set, all keys will be derived by using BIP39
+static const bool DEFAULT_USE_MNEMONIC = true;
+
 extern const char * DEFAULT_WALLET_DAT;
 
 const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;
@@ -1211,7 +1214,7 @@ public:
     void GenerateNewMnemonic();
 
     /* Set the current HD master key (will reset the chain child index counters) */
-    bool SetHDMasterKey(const CPubKey& key);
+    bool SetHDMasterKey(const CPubKey& key, const int cHDChainVersion=CHDChain().CURRENT_VERSION);
 };
 
 /** A key allocated from the key pool. */


### PR DESCRIPTION
- add `usemnemonic` conf setting, on by default (as we have with `usehd`). this allows us to create non-mnemonic wallets and block key imports to mnemonic wallets
- remove code that creates new master key for non-mnemonic wallets
