### PR TITLE
Fix Exodus mint creation

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -104,7 +104,7 @@ testScripts = [
     'exodus_create_denomination.py',
     'exodus_property_creation_fee.py',
     'exodus_sendmint.py',
-    'exodus_sendmint_wallet_encryption',
+    'exodus_sendmint_wallet_encryption.py',
     'exodus_sendspend.py',
     'exodus_sigma_reindex.py',
     'exodus_sigma_reorg.py',

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -104,6 +104,7 @@ testScripts = [
     'exodus_create_denomination.py',
     'exodus_property_creation_fee.py',
     'exodus_sendmint.py',
+    'exodus_sendmint_wallet_encryption',
     'exodus_sendspend.py',
     'exodus_sigma_reindex.py',
     'exodus_sigma_reorg.py',

--- a/qa/rpc-tests/exodus_sendmint_wallet_encryption.py
+++ b/qa/rpc-tests/exodus_sendmint_wallet_encryption.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from time import sleep
+from test_framework.authproxy import JSONRPCException
+from test_framework.test_framework import ExodusTestFramework
+from test_framework.util import (assert_equal, assert_raises_message, start_node, assert_equal, bitcoind_processes)
+
+class ExodusSendMintWalletEncrytionTest(ExodusTestFramework):
+    def run_test(self):
+        super().run_test()
+
+        sigma_start_block = 500
+
+        self.nodes[0].generatetoaddress(100, self.addrs[0])
+        self.nodes[0].generate(sigma_start_block - self.nodes[0].getblockcount())
+
+        self.nodes[0].exodus_sendissuancefixed(
+            self.addrs[0], 1, 1, 0, '', '', 'Sigma', '', '', '1000000', 1
+        )
+        self.nodes[0].generate(1)
+        sigmaProperty = 3
+
+        self.nodes[0].exodus_sendcreatedenomination(self.addrs[0], sigmaProperty, '1')
+        self.nodes[0].generate(10)
+
+        passphase = 'test'
+        self.nodes[0].encryptwallet(passphase)
+        bitcoind_processes[0].wait()
+        self.nodes[0] = start_node(0, self.options.tmpdir, ['-exodus'])
+
+        # try to mint using encrypted wallet
+        assert_raises_message(
+            JSONRPCException,
+            'Wallet locked',
+            self.nodes[0].exodus_sendmint, self.addrs[0], sigmaProperty, {"0":1}
+        )
+
+        self.nodes[0].walletpassphrase(passphase, 3)
+
+        self.nodes[0].exodus_sendmint(self.addrs[0], sigmaProperty, {"0":1})
+
+        sleep(3)
+
+        assert_raises_message(
+            JSONRPCException,
+            'Wallet locked',
+            self.nodes[0].exodus_sendmint, self.addrs[0], sigmaProperty, {"0":1}
+        )
+
+if __name__ == "__main__":
+    ExodusSendMintWalletEncrytionTest().main()

--- a/qa/rpc-tests/exodus_sendmint_wallet_encryption.py
+++ b/qa/rpc-tests/exodus_sendmint_wallet_encryption.py
@@ -2,7 +2,7 @@
 from time import sleep
 from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import ExodusTestFramework
-from test_framework.util import (assert_equal, assert_raises_message, start_node, assert_equal, bitcoind_processes)
+from test_framework.util import (assert_raises_message, start_node, bitcoind_processes)
 
 class ExodusSendMintWalletEncrytionTest(ExodusTestFramework):
     def run_test(self):

--- a/src/exodus/rpctx.cpp
+++ b/src/exodus/rpctx.cpp
@@ -1656,6 +1656,12 @@ UniValue exodus_sendmint(const UniValue& params, bool fHelp)
         if (result != 0) {
             throw JSONRPCError(result, error_str(result));
         }
+    } catch (WalletLocked e) {
+        for (auto& id : ids) {
+            wallet->DeleteUnconfirmedSigmaMint(id);
+        }
+        throw JSONRPCError(RPC_WALLET_ERROR, e.what());
+
     } catch (...) {
         for (auto& id : ids) {
             wallet->DeleteUnconfirmedSigmaMint(id);

--- a/src/exodus/rpctx.cpp
+++ b/src/exodus/rpctx.cpp
@@ -1644,10 +1644,14 @@ UniValue exodus_sendmint(const UniValue& params, bool fHelp)
     mints.reserve(denoms.size());
 
     try {
-        wallet->CreateSigmaMints(propertyId, denoms.begin(), denoms.end(), boost::make_function_output_iterator([&] (const SigmaMintId& m) {
-            ids.push_back(m);
-            mints.push_back(std::make_pair(m.denomination, m.pubKey));
-        }));
+        try {
+            wallet->CreateSigmaMints(propertyId, denoms.begin(), denoms.end(), boost::make_function_output_iterator([&] (const SigmaMintId& m) {
+                ids.push_back(m);
+                mints.push_back(std::make_pair(m.denomination, m.pubKey));
+            }));
+        } catch (WalletLocked const &e) {
+            throw JSONRPCError(RPC_WALLET_ERROR, e.what());
+        }
 
         // Create transaction.
         auto payload = CreatePayload_SimpleMint(propertyId, mints);
@@ -1656,12 +1660,6 @@ UniValue exodus_sendmint(const UniValue& params, bool fHelp)
         if (result != 0) {
             throw JSONRPCError(result, error_str(result));
         }
-    } catch (WalletLocked e) {
-        for (auto& id : ids) {
-            wallet->DeleteUnconfirmedSigmaMint(id);
-        }
-        throw JSONRPCError(RPC_WALLET_ERROR, e.what());
-
     } catch (...) {
         for (auto& id : ids) {
             wallet->DeleteUnconfirmedSigmaMint(id);

--- a/src/exodus/sigmawallet.cpp
+++ b/src/exodus/sigmawallet.cpp
@@ -13,6 +13,7 @@
 
 #include "../wallet/wallet.h"
 #include "../wallet/walletdb.h"
+#include "../wallet/walletexcept.h"
 
 #include <boost/optional.hpp>
 
@@ -186,8 +187,18 @@ SigmaMintId SigmaWallet::GenerateMint(PropertyId property, SigmaDenomination den
 
     // If not specify seed to use that mean caller want to generate a new mint.
     if (!seedId) {
+        if (pwalletMain->IsLocked()) {
+            throw WalletLocked();
+        }
+
         if (mintPool.empty()) {
-            throw std::runtime_error("Mint pool is empty");
+
+            // Try to recover mint pools
+            ReloadMasterKey();
+
+            if (mintPool.empty()) {
+                throw std::runtime_error("Mint pool is empty");
+            }
         }
 
         seedId = mintPool.begin()->seedId;


### PR DESCRIPTION
## PR intention
Fix problem when user try to mint on encrypted wallet. closes https://github.com/zcoinofficial/zcoin/issues/764

## Code changes brief
- Add logic to check when wallet is lock then throw exception to tell user to unlock wallet.
- Add logic to recover mint pool when try to mint after unlock wallet.
- Add python test