### PR TITLE
Fixed tor library picking wrong openssl library on MacOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1194,6 +1194,10 @@ if test "x$have_zstd" = "xyes"; then
 fi
 AC_SUBST(LIBZSTD)
 
+if test x$openssl_prefix != x; then
+  ac_configure_args="$ac_configure_args --with-openssl-dir=$openssl_prefix"
+fi
+
 AX_SUBDIRS_CONFIGURE([src/secp256k1], [[--disable-shared], [--with-pic], [--with-bignum=no], [--enable-module-recovery], [--enable-experimental], [--enable-module-ecdh]])
 AX_SUBDIRS_CONFIGURE([src/tor], [[--disable-system-torrc], [--disable-systemd], [--disable-lzma], [--disable-asciidoc], [--disable-libscrypt]])
 


### PR DESCRIPTION
## PR intention
Latest `brew` version deprecated OpenSSL 1.0.* but `tor` was unable to pick up the new version

## Code changes brief
Forced every dependency (`tor` and `secp256k1`) to use the same version that our code is using by adding `--with-openssl-dir` option
