### PR TITLE
Fix issue with old Zerocoin import

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -475,7 +475,7 @@ UniValue importwallet(const UniValue& params, bool fHelp)
             zerocoinEntry.IsUsed = stoi(vstr[5]);
             zerocoinEntry.nHeight = stoi(vstr[6]);
             zerocoinEntry.id = stoi(vstr[7]);
-            if(vstr.size()>8){
+            if(vstr.size()==11){ // Including the last "#"
                 zerocoinEntry.ecdsaSecretKey = ParseHex(vstr[8]);
                 zerocoinEntry.IsUsedForRemint = stoi(vstr[9]);
             }


### PR DESCRIPTION
## PR intention
Fixes an issue with importing Zerocoins from before the ECDSA key was introduced.

## Code changes brief
On import, the string containing Zerocoin data is split into `n` elements. The last of these elements is a `#`, which is a delimiter for the next line. This extra element was not taken into account when attempting to import the ECDSA key and `IsUsedForRemint` boolean - old Zerocoins would try to import this values, leading to a bad access.
