### PR TITLE
Qt Sigma page updates

### DIFF
--- a/src/qt/sigmacoincontroldialog.cpp
+++ b/src/qt/sigmacoincontroldialog.cpp
@@ -486,7 +486,7 @@ void SigmaCoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     std::vector<COutPoint> vCoinControl;
     std::vector<COutput>   vOutputs;
     coinControl->ListSelected(vCoinControl);
-    model->getOutputs(vCoinControl, vOutputs);
+    model->getOutputs(vCoinControl, vOutputs, fMintTabSelected);
 
     BOOST_FOREACH(const COutput& out, vOutputs) {
         // unselect already spent, very unlikely scenario, this could happen

--- a/src/qt/sigmadialog.cpp
+++ b/src/qt/sigmadialog.cpp
@@ -108,6 +108,7 @@ SigmaDialog::SigmaDialog(const PlatformStyle *platformStyle, QWidget *parent) :
     ui->labelCoinControlChange->addAction(clipboardChangeAction);
 
     ui->amountToMint->setLocale(QLocale::c());
+    connect(ui->amountToMint, SIGNAL(valueChanged(double)), this, SLOT(coinControlUpdateLabels()));
 
     //check if user clicked at a tab
     connect(ui->tabWidget, SIGNAL(currentChanged(int)), this, SLOT(tabSelected()));
@@ -166,6 +167,9 @@ void SigmaDialog::tabSelected(){
         if(coinControlSelected)
             ui->coinControlChange->hide();
     }
+    // reset the coin control window on a tab change (preserves the backend so the state is the same when returning)
+    if(coinControlSelected)
+        coinControlUpdateLabels();
 }
 
 SigmaDialog::~SigmaDialog()
@@ -464,11 +468,15 @@ void SigmaDialog::accept()
     clear();
 }
 
+void SigmaDialog::reject(){}
+
 SendCoinsEntry *SigmaDialog::addEntry() {
     SendCoinsEntry *entry = new SendCoinsEntry(platformStyle, this);
     entry->setModel(walletModel);
     ui->entries->addWidget(entry);
     connect(entry, SIGNAL(removeEntry(SendCoinsEntry*)), this, SLOT(removeEntry(SendCoinsEntry*)));
+    connect(entry, SIGNAL(payAmountChanged()), this, SLOT(coinControlUpdateLabels()));
+    connect(entry, SIGNAL(subtractFeeFromAmountChanged()), this, SLOT(coinControlUpdateLabels()));
 
     // Focus the field, so that entry can start immediately
     entry->clear();
@@ -565,17 +573,22 @@ void SigmaDialog::coinControlUpdateLabels()
     // set pay amounts
     SigmaCoinControlDialog::payAmounts.clear();
     SigmaCoinControlDialog::fSubtractFeeFromAmount = false;
-    for(int i = 0; i < ui->entries->count(); ++i)
-    {
-        SendCoinsEntry *entry = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
-        if(entry && !entry->isHidden())
+    if(SigmaCoinControlDialog::fMintTabSelected){
+        SigmaCoinControlDialog::payAmounts.append(ui->amountToMint->value() * COIN);
+    }else{
+        for(int i = 0; i < ui->entries->count(); ++i)
         {
-            SendCoinsRecipient rcp = entry->getValue();
-            SigmaCoinControlDialog::payAmounts.append(rcp.amount);
-            if (rcp.fSubtractFeeFromAmount)
-                SigmaCoinControlDialog::fSubtractFeeFromAmount = true;
+            SendCoinsEntry *entry = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(i)->widget());
+            if(entry && !entry->isHidden())
+            {
+                SendCoinsRecipient rcp = entry->getValue();
+                SigmaCoinControlDialog::payAmounts.append(rcp.amount);
+                if (rcp.fSubtractFeeFromAmount)
+                    SigmaCoinControlDialog::fSubtractFeeFromAmount = true;
+            }
         }
     }
+
 
     if (SigmaCoinControlDialog::coinControl->HasSelected())
     {

--- a/src/qt/sigmadialog.h
+++ b/src/qt/sigmadialog.h
@@ -45,6 +45,7 @@ public:
 public Q_SLOTS:
     void clear();
     void accept();
+    void reject();
     SendCoinsEntry* addEntry();
     void coinControlFeatureChanged(bool);
     void updateTabsAndLabels();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -668,7 +668,7 @@ bool WalletModel::havePrivKey(const CKeyID &address) const
 }
 
 // returns a list of COutputs from COutPoints
-void WalletModel::getOutputs(const std::vector<COutPoint>& vOutpoints, std::vector<COutput>& vOutputs)
+void WalletModel::getOutputs(const std::vector<COutPoint>& vOutpoints, std::vector<COutput>& vOutputs, boost::optional<bool> fMintTabSelected)
 {
     LOCK2(cs_main, wallet->cs_wallet);
     BOOST_FOREACH(const COutPoint& outpoint, vOutpoints)
@@ -676,6 +676,15 @@ void WalletModel::getOutputs(const std::vector<COutPoint>& vOutpoints, std::vect
         if (!wallet->mapWallet.count(outpoint.hash)) continue;
         int nDepth = wallet->mapWallet[outpoint.hash].GetDepthInMainChain();
         if (nDepth < 0) continue;
+        if(fMintTabSelected!=boost::none){
+            if(wallet->mapWallet[outpoint.hash].vout[outpoint.n].scriptPubKey.IsSigmaMint()){
+                if(fMintTabSelected.get()) // only allow mint outputs on the "Spend" tab
+                    continue;
+            }else{
+                if(!fMintTabSelected.get())
+                    continue; // only allow normal outputs on the "Mint" tab
+            }
+        }
         COutput out(&wallet->mapWallet[outpoint.hash], outpoint.n, nDepth, true, true);
         vOutputs.push_back(out);
     }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -194,7 +194,7 @@ public:
 
     bool getPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const;
     bool havePrivKey(const CKeyID &address) const;
-    void getOutputs(const std::vector<COutPoint>& vOutpoints, std::vector<COutput>& vOutputs);
+    void getOutputs(const std::vector<COutPoint>& vOutpoints, std::vector<COutput>& vOutputs, boost::optional<bool> fMintTabSelected = boost::none);
     bool isSpent(const COutPoint& outpoint) const;
     void listCoins(std::map<QString, std::vector<COutput> >& mapCoins, AvailableCoinsType nCoinType=ALL_COINS) const;
 


### PR DESCRIPTION
## PR intention
Fixes https://github.com/zcoinofficial/zcoin/issues/784
Fixes and updates for the Sigma page in Qt

## Code changes brief
- Update "Coin Control Features" layout when "amount to mint" or "Amount" changed at mint/spend tab respectively
- Clear the "Coin Control Features" layout when switching between mint/spend tabs - but preserve the backend state so that the same selection is there when switching back
- Ensure only correct outputs considered for selection - normal outputs for the mint tab and mint outputs for the spend tab
- Also fixes an issue where entire page disappears if escape key pressed without an element focused.
