### PR TITLE
Ban zcoin nodes with version < 0.13.8.8

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -49,6 +49,6 @@ static const int SHORT_IDS_BLOCKS_VERSION = 90013;
 static const int INVALID_CB_NO_BAN_VERSION = 90013;
 
 //! minimum version of official client to connect to
-static const int MIN_ZCOIN_CLIENT_VERSION = 130805; // 0.13.8.5
+static const int MIN_ZCOIN_CLIENT_VERSION = 130808; // 0.13.8.8
 
 #endif // BITCOIN_VERSION_H

--- a/src/version.h
+++ b/src/version.h
@@ -49,6 +49,6 @@ static const int SHORT_IDS_BLOCKS_VERSION = 90013;
 static const int INVALID_CB_NO_BAN_VERSION = 90013;
 
 //! minimum version of official client to connect to
-static const int MIN_ZCOIN_CLIENT_VERSION = 130802; // 0.13.8.2
+static const int MIN_ZCOIN_CLIENT_VERSION = 130805; // 0.13.8.5
 
 #endif // BITCOIN_VERSION_H


### PR DESCRIPTION
## PR intention
Ban versions of Zcoin client 0.13.8.5 and below

## Code changes brief
"Parse standard client version string in form of /Satosh:0.x.y.z/ and drop connection with every legacy node" - As per #742 
