### PR TITLE
Fix DB deadlock in NewKeyPool

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1486,13 +1486,16 @@ bool CWallet::SetHDMasterKey(const CPubKey &pubkey, const int cHDChainVersion) {
     return true;
 }
 
-bool CWallet::SetHDChain(const CHDChain &chain, bool memonly) {
+bool CWallet::SetHDChain(const CHDChain &chain, bool memonly, bool& upgradeChain, bool genNewKeyPool) {
     LOCK(cs_wallet);
-    bool upgradeChain = (chain.nVersion==CHDChain::VERSION_BASIC);
-    if(upgradeChain && !IsLocked()){ // Upgrade HDChain to latest version
+    upgradeChain = (chain.nVersion==CHDChain::VERSION_BASIC);
+    if (upgradeChain && !IsLocked()){ // Upgrade HDChain to latest version
         CHDChain newChain;
         newChain.masterKeyID = chain.masterKeyID;
-        NewKeyPool();
+        newChain.nVersion = CHDChain::VERSION_WITH_BIP44; // old versions cannot use mnemonic
+        // whether to generate the keypool now (conditional as leads to DB deadlock if loading DB simultaneously)
+        if (genNewKeyPool)
+            NewKeyPool();
         if (!memonly && !CWalletDB(strWalletFile).WriteHDChain(newChain))
             throw runtime_error(std::string(__func__) + ": writing chain failed");
         hdChain = newChain;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -72,6 +72,8 @@ static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 2;
 static const unsigned int MAX_FREE_TRANSACTION_CREATE_SIZE = 1000;
 static const bool DEFAULT_WALLETBROADCAST = true;
 
+static bool DEFAULT_UPGRADE_CHAIN = false;
+
 //! if set, all keys will be derived by using BIP32
 static const bool DEFAULT_USE_HD_WALLET = true;
 
@@ -1200,7 +1202,7 @@ public:
     bool BackupWallet(const std::string& strDest);
 
     /* Set the HD chain model (chain child index counters) */
-    bool SetHDChain(const CHDChain& chain, bool memonly);
+    bool SetHDChain(const CHDChain& chain, bool memonly, bool& upgradeChain = DEFAULT_UPGRADE_CHAIN, bool genNewKeyPool = true);
     const CHDChain& GetHDChain() { return hdChain; }
 
     bool SetMnemonicContainer(const MnemonicContainer& mnContainer, bool memonly);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -860,8 +860,6 @@ DBErrors CWalletDB::LoadWallet(CWallet *pwallet) {
     if (result != DB_LOAD_OK)
         return result;
 
-
-
     LogPrintf("nFileVersion = %d\n", wss.nFileVersion);
 
     LogPrintf("Keys: %u plaintext, %u encrypted, %u w/ metadata, %u total\n",
@@ -893,7 +891,7 @@ DBErrors CWalletDB::LoadWallet(CWallet *pwallet) {
     }
 
     // unencrypted wallets upgrading the wallet version get a new keypool here
-    if(wss.fUpgradeHDChain && !pwallet->IsLocked())
+    if (wss.fUpgradeHDChain && !pwallet->IsLocked())
         pwallet->NewKeyPool();
 
     return result;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -537,6 +537,7 @@ public:
     unsigned int nKeyMeta;
     bool fIsEncrypted;
     bool fAnyUnordered;
+    bool fUpgradeHDChain;
     int nFileVersion;
     vector <uint256> vWalletUpgrade;
 
@@ -544,6 +545,7 @@ public:
         nKeys = nCKeys = nKeyMeta = 0;
         fIsEncrypted = false;
         fAnyUnordered = false;
+        fUpgradeHDChain = false;
         nFileVersion = 0;
     }
 };
@@ -762,7 +764,7 @@ bool ReadKeyValue(CWallet *pwallet, CDataStream &ssKey, CDataStream &ssValue,
         } else if (strType == "hdchain") {
             CHDChain chain;
             ssValue >> chain;
-            if (!pwallet->SetHDChain(chain, true)) {
+            if (!pwallet->SetHDChain(chain, true, wss.fUpgradeHDChain, false)) {
                 strErr = "Error reading wallet database: SetHDChain failed";
                 return false;
             }
@@ -858,6 +860,8 @@ DBErrors CWalletDB::LoadWallet(CWallet *pwallet) {
     if (result != DB_LOAD_OK)
         return result;
 
+
+
     LogPrintf("nFileVersion = %d\n", wss.nFileVersion);
 
     LogPrintf("Keys: %u plaintext, %u encrypted, %u w/ metadata, %u total\n",
@@ -887,6 +891,10 @@ DBErrors CWalletDB::LoadWallet(CWallet *pwallet) {
     {
         pwallet->wtxOrdered.insert(make_pair(entry.nOrderPos, CWallet::TxPair((CWalletTx *) 0, &entry)));
     }
+
+    // unencrypted wallets upgrading the wallet version get a new keypool here
+    if(wss.fUpgradeHDChain && !pwallet->IsLocked())
+        pwallet->NewKeyPool();
 
     return result;
 }


### PR DESCRIPTION
## PR intention
Fixes an issue with a DB deadlock when calling `NewKeyPool()` during wallet load. This occurs during the upgrade of unencrypted wallets to Sigma. 
Also correctly sets the `CHDChain` version to `VERSION_WITH_BIP44` rather than the now default `VERSION_WITH_BIP39`.

