### PR TITLE
Remove unnecessary bool arg (Fix for #807)

### DIFF
--- a/src/qt/recover.cpp
+++ b/src/qt/recover.cpp
@@ -95,7 +95,6 @@ bool Recover::askRecover(bool& newWallet)
     if(!fs::exists(GUIUtil::qstringToBoostPath(QString::fromStdString(dataDir))))
     {
         newWallet = true;
-        SoftSetBoolArg("-rescanmnemonic", true);
         Recover recover;
         recover.setWindowIcon(QIcon(":icons/zcoin"));
         while(true)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -8041,6 +8041,7 @@ bool CWallet::InitLoadWallet() {
     uiInterface.InitMessage(_("Loading wallet..."));
     int64_t nStart = GetTimeMillis();
     bool fFirstRun = true;
+    bool fRecoverMnemonic = false;
     CWallet *walletInstance = new CWallet(walletFile);
     pwalletMain = walletInstance;
 
@@ -8092,6 +8093,7 @@ bool CWallet::InitLoadWallet() {
                  * if blockchain data is not present it has no effect, but it's needed for a mnemonic restore where chain data is present.
                  */
                 SoftSetBoolArg("-rescan", true);
+                fRecoverMnemonic = true;
             }else{
             // generate a new master key
             CPubKey masterPubKey = walletInstance->GenerateNewHDMasterKey();
@@ -8156,9 +8158,6 @@ bool CWallet::InitLoadWallet() {
         LogPrintf("Rescanning last %i blocks (from block %i)...\n", chainActive.Height() - pindexRescan->nHeight,
                   pindexRescan->nHeight);
         nStart = GetTimeMillis();
-        bool fRecoverMnemonic = false;
-        if (GetBoolArg("-rescanmnemonic", false))
-            fRecoverMnemonic = true;
         walletInstance->ScanForWalletTransactions(pindexRescan, true, fRecoverMnemonic);
         LogPrintf(" rescan      %15dms\n", GetTimeMillis() - nStart);
         walletInstance->SetBestChain(chainActive.GetLocator());


### PR DESCRIPTION
Opening as PR to allow review from @levonpetrosyan93 

Two issues:
- setting a bool arg implies it's a setting that can be turned on/off by the user. If the user is loading a mnemonic, they will always be rescanning the chain. Therefore `-rescanmnemonic` is overkill
- The PR does not handle the case where the user loads the mnemonic from the conf file only (eg. from `zcoind` and not `zcoin-qt`). So in the current PR the chain would not be rescanned with the bool arg.

So instead, just set the `fRecoverMnemonic` bool as true in the section where the mnemonic is initialized. This section will be reached whether the mnemonic is being recovered from Qt or zcoind.