### PR TITLE
Add ZCS to Github Funding Button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://zcs.zcoin.io", zcs.zcoin.io]


### PR DESCRIPTION
This is a trivial PR, just adding a funding yml file into the .github directory so that if the repo owner enables the funding button option the option for donation to the ZCS will be enabled. 

[Source](https://help.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository)
