### PR TITLE
Add CI for all supported platforms

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -62,4 +62,4 @@ jobs:
       run: |
         ./autogen.sh
         ./configure --enable-exodus
-        make -j$(nproc)
+        make -j$(sysctl -n hw.activecpu)

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -2,9 +2,9 @@ name: Continuous Integration on Master
 on:
   push:
     branches:
-      - master
+    - master
 jobs:
-  target-unix:
+  target-linux:
     name: Target Linux
     runs-on: ubuntu-latest
     steps:
@@ -15,12 +15,12 @@ jobs:
         sudo apt update
         sudo apt-get install -y ccache python3-zmq
     - name: Build dependencies
-      run: make -C depends -j2 HOST=x86_64-unknown-linux-gnu
+      run: make -C depends -j$(nproc) HOST=x86_64-unknown-linux-gnu
     - name: Build Zcoin
       run: |
         ./autogen.sh
         ./configure --enable-exodus --enable-tests --with-comparison-tool=no --prefix=$(pwd)/depends/x86_64-unknown-linux-gnu
-        make -j2
+        make -j$(nproc)
     - name: Unit Tests
       run: make check
     - name: RPC Tests
@@ -38,17 +38,17 @@ jobs:
       run: |
         sudo apt update
         sudo apt install -y ccache g++-mingw-w64-x86-64 mingw-w64-x86-64-dev
-    - name: Update gcc mingw
-      run: sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
-    - name: Update g++ mingw
-      run: sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
+    - name: Switch MinGW GCC and G++ to POSIX Threading
+      run: |
+        sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
+        sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
     - name: Build dependencies
-      run: make -C depends -j2 HOST=x86_64-w64-mingw32
+      run: make -C depends -j$(nproc) HOST=x86_64-w64-mingw32
     - name: Build Zcoin
       run: |
         ./autogen.sh
         ./configure --disable-jni --enable-exodus --prefix=$(pwd)/depends/x86_64-w64-mingw32
-        make -j2
+        make -j$(nproc)
 
   target-macos:
     name: Target macOS
@@ -67,9 +67,9 @@ jobs:
     - name: Extract SDK
       run: tar -C depends/SDKs -xf /tmp/MacOSX10.11.sdk.tar.gz
     - name: Build dependencies
-      run: make -C depends -j2 HOST=x86_64-apple-darwin11
+      run: make -C depends -j$(nproc) HOST=x86_64-apple-darwin11
     - name: Build Zcoin
       run: |
         ./autogen.sh
         ./configure --enable-exodus --prefix=$(pwd)/depends/x86_64-apple-darwin11
-        make -j2
+        make -j$(nproc)

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -1,0 +1,75 @@
+name: Continuous Integration on Master
+on:
+  push:
+    branches:
+      - master
+jobs:
+  target-unix:
+    name: Target Linux
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt-get install -y ccache python3-zmq
+    - name: Build dependencies
+      run: make -C depends -j2 HOST=x86_64-unknown-linux-gnu
+    - name: Build Zcoin
+      run: |
+        ./autogen.sh
+        ./configure --enable-exodus --enable-tests --with-comparison-tool=no --prefix=$(pwd)/depends/x86_64-unknown-linux-gnu
+        make -j2
+    - name: Unit Tests
+      run: make check
+    - name: RPC Tests
+      env:
+        TIMEOUT: 600
+      run: qa/pull-tester/rpc-tests.py -extended
+
+  target-windows:
+    name: Target Windows
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y ccache g++-mingw-w64-x86-64 mingw-w64-x86-64-dev
+    - name: Update gcc mingw
+      run: sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
+    - name: Update g++ mingw
+      run: sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
+    - name: Build dependencies
+      run: make -C depends -j2 HOST=x86_64-w64-mingw32
+    - name: Build Zcoin
+      run: |
+        ./autogen.sh
+        ./configure --disable-jni --enable-exodus --prefix=$(pwd)/depends/x86_64-w64-mingw32
+        make -j2
+
+  target-macos:
+    name: Target macOS
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt-get install -y ccache libcap-dev
+    - name: Prepare directory for SDKs
+      run: mkdir -p depends/SDKs
+    - name: Download SDK
+      run: curl -L -o /tmp/MacOSX10.11.sdk.tar.gz https://bitcoincore.org/depends-sources/sdks/MacOSX10.11.sdk.tar.gz
+    - name: Extract SDK
+      run: tar -C depends/SDKs -xf /tmp/MacOSX10.11.sdk.tar.gz
+    - name: Build dependencies
+      run: make -C depends -j2 HOST=x86_64-apple-darwin11
+    - name: Build Zcoin
+      run: |
+        ./autogen.sh
+        ./configure --enable-exodus --prefix=$(pwd)/depends/x86_64-apple-darwin11
+        make -j2

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -52,24 +52,14 @@ jobs:
 
   target-macos:
     name: Target macOS
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v1
     - name: Install dependencies
-      run: |
-        sudo apt update
-        sudo apt-get install -y ccache libcap-dev
-    - name: Prepare directory for SDKs
-      run: mkdir -p depends/SDKs
-    - name: Download SDK
-      run: curl -L -o /tmp/MacOSX10.11.sdk.tar.gz https://bitcoincore.org/depends-sources/sdks/MacOSX10.11.sdk.tar.gz
-    - name: Extract SDK
-      run: tar -C depends/SDKs -xf /tmp/MacOSX10.11.sdk.tar.gz
-    - name: Build dependencies
-      run: make -C depends -j$(nproc) HOST=x86_64-apple-darwin11
+      run: brew install automake berkeley-db4 libtool boost miniupnpc pkg-config python qt libevent qrencode ccache
     - name: Build Zcoin
       run: |
         ./autogen.sh
-        ./configure --enable-exodus --prefix=$(pwd)/depends/x86_64-apple-darwin11
+        ./configure --enable-exodus
         make -j$(nproc)


### PR DESCRIPTION
## PR intention
Resolve the problem that we fail to build target Windows and mac OS when we build release. This PR will enable GitHub actions to build target all supported platforms when master is change.

## Code changes brief
This script has 3 separated jobs that build target Linux(run unit tests and RPC tests), Windows and mac OS

Closes https://github.com/zcoinofficial/zcoin/issues/766
