### PR TITLE
Add exodus spend test after wallet is encrypted

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -157,7 +157,7 @@ testScripts = [
     'wallet_dumpnonhd.py',
     'wallet_dumpsigma.py',
     'wallet_dumpzerocoin.py',
-    'transations_verification_after_restart.py',
+    'transactions_verification_after_restart.py',
     'sigma_remint_lockedwallet.py',
     'sigma_zapwalletmints.py',
     'sigma_nonhd_wallet.py',

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -109,6 +109,7 @@ testScripts = [
     'exodus_sendspend_wallet_encryption.py',
     'exodus_sigma_reindex.py',
     'exodus_sigma_reorg.py',
+    'exodus_walletrecovery.py',
     'mempool_doublesend_oneblock.py',
     'mempool_reorg.py',
     'mempool_spendcoinbase.py',

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -106,6 +106,7 @@ testScripts = [
     'exodus_sendmint.py',
     'exodus_sendmint_wallet_encryption.py',
     'exodus_sendspend.py',
+    'exodus_sendspend_wallet_encryption.py',
     'exodus_sigma_reindex.py',
     'exodus_sigma_reorg.py',
     'mempool_doublesend_oneblock.py',

--- a/qa/rpc-tests/exodus_sendspend_wallet_encryption.py
+++ b/qa/rpc-tests/exodus_sendspend_wallet_encryption.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python3
 from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import ExodusTestFramework
-from test_framework.util import (assert_equal, assert_raises_message, start_node, bitcoind_processes)
+from test_framework.util import (
+    assert_equal,
+    assert_raises_message,
+    bitcoind_processes,
+    connect_nodes,
+    start_node,
+    sync_blocks)
 
 class ExodusSendSpendWalletEncryptionTest(ExodusTestFramework):
     def run_test(self):
@@ -44,7 +50,10 @@ class ExodusSendSpendWalletEncryptionTest(ExodusTestFramework):
         # encrypt wallet && restart node
         self.nodes[0].encryptwallet(passphase)
         bitcoind_processes[0].wait()
-        self.nodes[0] = start_node(0, self.options.tmpdir, ['-exodus'])
+        self.nodes[0] = start_node(0, self.options.tmpdir, ['-exodus', '-reindex'])
+        connect_nodes(self.nodes[0], 1)
+
+        sync_blocks(self.nodes)
 
         # try to spend using encrypted wallet
         assert_raises_message(

--- a/qa/rpc-tests/exodus_sendspend_wallet_encryption.py
+++ b/qa/rpc-tests/exodus_sendspend_wallet_encryption.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+from test_framework.authproxy import JSONRPCException
+from test_framework.test_framework import ExodusTestFramework
+from test_framework.util import (assert_equal, assert_raises_message, start_node, bitcoind_processes)
+
+class ExodusSendSpendWalletEncryptionTest(ExodusTestFramework):
+    def run_test(self):
+        super().run_test()
+
+        sigma_start_block = 550
+        passphase = "1234"
+
+        owner = self.addrs[0]
+
+        self.nodes[0].generatetoaddress(
+            sigma_start_block - self.nodes[0].getblockcount(),
+            owner)
+        self.sync_all()
+
+        # create sigma
+        for _ in range(0, 10):
+            self.nodes[0].mint(1)
+
+        self.nodes[0].generate(10)
+
+        # create property
+        self.nodes[0].exodus_sendissuancefixed(
+            owner, 1, 1, 0, '', '', 'Sigma', '', '', '1000000', 1)
+
+        self.nodes[0].generate(1)
+        sigmaProperty = 3
+
+        self.nodes[0].exodus_sendcreatedenomination(owner, sigmaProperty, '1')
+        self.nodes[0].generate(10)
+
+        # mint 2 coins
+        self.nodes[0].exodus_sendmint(owner, sigmaProperty, {"0": 2})
+        self.nodes[0].generate(10)
+
+        # spend a coin
+        self.nodes[0].exodus_sendspend(owner, sigmaProperty, 0)
+        self.nodes[0].generate(1)
+
+        # encrypt wallet && restart node
+        self.nodes[0].encryptwallet(passphase)
+        bitcoind_processes[0].wait()
+        self.nodes[0] = start_node(0, self.options.tmpdir, ['-exodus'])
+
+        # try to spend using encrypted wallet
+        assert_raises_message(
+            JSONRPCException,
+            'wallet locked',
+            self.nodes[0].exodus_sendspend, owner, sigmaProperty, 0)
+
+        # Unlock
+        self.nodes[0].walletpassphrase(passphase, 10)
+
+        # One coin remaining
+        unspends = self.nodes[0].exodus_listmints()
+        assert_equal(1, len(unspends))
+
+        # Spend another coin
+        self.nodes[0].exodus_sendspend(owner, sigmaProperty, 0)
+
+        # No remaining coin
+        unspends = self.nodes[0].exodus_listmints()
+        assert_equal(0, len(unspends))
+
+if __name__ == '__main__':
+    ExodusSendSpendWalletEncryptionTest().main()

--- a/qa/rpc-tests/exodus_sendspend_wallet_encryption.py
+++ b/qa/rpc-tests/exodus_sendspend_wallet_encryption.py
@@ -7,8 +7,7 @@ from test_framework.util import (
     assert_raises_message,
     bitcoind_processes,
     connect_nodes,
-    start_node,
-    sync_blocks)
+    start_node)
 
 class ExodusSendSpendWalletEncryptionTest(ExodusTestFramework):
     def run_test(self):

--- a/qa/rpc-tests/exodus_sendspend_wallet_encryption.py
+++ b/qa/rpc-tests/exodus_sendspend_wallet_encryption.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import time
 from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import ExodusTestFramework
 from test_framework.util import (
@@ -47,13 +48,16 @@ class ExodusSendSpendWalletEncryptionTest(ExodusTestFramework):
         self.nodes[0].exodus_sendspend(owner, sigmaProperty, 0)
         self.nodes[0].generate(1)
 
+        blockcount = self.nodes[0].getblockcount()
+
         # encrypt wallet && restart node
         self.nodes[0].encryptwallet(passphase)
         bitcoind_processes[0].wait()
         self.nodes[0] = start_node(0, self.options.tmpdir, ['-exodus', '-reindex'])
-        connect_nodes(self.nodes[0], 1)
+        while self.nodes[0].getblockcount() < blockcount:
+            time.sleep(0.1)
 
-        sync_blocks(self.nodes)
+        connect_nodes(self.nodes[0], 1)
 
         # try to spend using encrypted wallet
         assert_raises_message(

--- a/qa/rpc-tests/exodus_walletrecovery.py
+++ b/qa/rpc-tests/exodus_walletrecovery.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+import time
+import os
+import shutil
+from test_framework.authproxy import JSONRPCException
+from test_framework.test_framework import ExodusTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes_bi,
+    start_node,
+    stop_node,
+    sync_blocks)
+
+class ExodusWalletRecoveryTest(ExodusTestFramework):
+    def get_datadir(self, node = 0):
+        return os.path.join(self.options.tmpdir, f"node{node}", "regtest")
+
+    def get_walletfile(self, node = 0):
+        datadir = self.get_datadir(node)
+        return os.path.join(datadir, "wallet.dat")
+
+    def load_wallet_content(self, node = 0):
+        with open(self.get_walletfile(node), mode='rb') as f:
+            return f.read()
+
+    def clear_datadir(self, node = 0):
+        datadir = self.get_datadir(node)
+        shutil.rmtree(datadir)
+        os.mkdir(datadir)
+
+    def connect_to_other(self, node = 0):
+        for i in range(0, 4):
+            if i != node:
+                connect_nodes_bi(self.nodes, node, i)
+
+    def run_test(self):
+        # stop node and read wallet.dat
+        stop_node(self.nodes[0], 0)
+        fresh_wallet_content = self.load_wallet_content(0)
+
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-exodus"])
+        self.connect_to_other()
+
+        super().run_test()
+
+        # generate sigma property
+        owner = self.addrs[0]
+
+        sigma_start_block = 550
+        self.nodes[0].generatetoaddress(
+            sigma_start_block - self.nodes[0].getblockcount(),
+            owner)
+
+        self.nodes[0].exodus_sendissuancefixed(
+            owner, 1, 1, 0, '', '', 'Test Sigma', '', '', '3', 1)
+
+        self.nodes[0].generate(10)
+        sigmaProperty = 3
+
+        self.nodes[0].exodus_sendcreatedenomination(owner, sigmaProperty, '1')
+        self.nodes[0].generate(10)
+
+        # generate two coins and spend one of them
+        self.nodes[0].exodus_sendmint(owner, sigmaProperty, {"0": 2})
+        self.nodes[0].generate(10)
+
+        for _ in range(10):
+            self.nodes[0].mint(1)
+
+        self.nodes[0].generate(10)
+
+        self.nodes[0].exodus_sendspend(owner, sigmaProperty, 0)
+        self.nodes[0].generate(10)
+
+        sync_blocks(self.nodes)
+
+        # stop, clear state and restore fresh wallet
+        stop_node(self.nodes[0], 0)
+        self.clear_datadir(0)
+
+        walletfile = self.get_walletfile(0)
+        with open(walletfile, 'wb+') as wf:
+            wf.write(fresh_wallet_content)
+
+        # start and sync
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-exodus"])
+        self.connect_to_other()
+
+        sync_blocks(self.nodes)
+
+        # verify state
+        unspents = self.nodes[0].exodus_listmints()
+        assert_equal(1, len(unspents))
+        assert_equal('2', self.nodes[0].exodus_getbalance(owner, sigmaProperty)['balance'])
+
+        self.nodes[0].exodus_sendspend(owner, sigmaProperty, 0)
+        self.nodes[0].generate(10)
+
+        unspents = self.nodes[0].exodus_listmints()
+        assert_equal(0, len(unspents))
+        assert_equal('3', self.nodes[0].exodus_getbalance(owner, sigmaProperty)['balance'])
+
+if __name__ == '__main__':
+    ExodusWalletRecoveryTest().main()

--- a/qa/rpc-tests/exodus_walletrecovery.py
+++ b/qa/rpc-tests/exodus_walletrecovery.py
@@ -10,24 +10,24 @@ from test_framework.util import (
     sync_blocks)
 
 class ExodusWalletRecoveryTest(ExodusTestFramework):
-    def get_datadir(self, node = 0):
+    def get_datadir(self, node):
         return os.path.join(self.options.tmpdir, f"node{node}", "regtest")
 
-    def get_walletfile(self, node = 0):
+    def get_walletfile(self, node):
         datadir = self.get_datadir(node)
         return os.path.join(datadir, "wallet.dat")
 
-    def load_wallet_content(self, node = 0):
+    def load_wallet_content(self, node):
         with open(self.get_walletfile(node), mode='rb') as f:
             return f.read()
 
-    def clear_datadir(self, node = 0):
+    def clear_datadir(self, node):
         datadir = self.get_datadir(node)
         rmtree(datadir)
         os.mkdir(datadir)
 
-    def connect_to_other(self, node = 0):
-        for i in range(0, 4):
+    def connect_to_other(self, node):
+        for i in range(0, len(self.nodes)):
             if i != node:
                 connect_nodes_bi(self.nodes, node, i)
 
@@ -37,7 +37,7 @@ class ExodusWalletRecoveryTest(ExodusTestFramework):
         fresh_wallet_content = self.load_wallet_content(0)
 
         self.nodes[0] = start_node(0, self.options.tmpdir, ["-exodus"])
-        self.connect_to_other()
+        self.connect_to_other(0)
 
         super().run_test()
 
@@ -82,7 +82,7 @@ class ExodusWalletRecoveryTest(ExodusTestFramework):
 
         # start and sync
         self.nodes[0] = start_node(0, self.options.tmpdir, ["-exodus"])
-        self.connect_to_other()
+        self.connect_to_other(0)
 
         sync_blocks(self.nodes)
 

--- a/qa/rpc-tests/exodus_walletrecovery.py
+++ b/qa/rpc-tests/exodus_walletrecovery.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
-import time
 import os
-import shutil
-from test_framework.authproxy import JSONRPCException
+from shutil import rmtree
 from test_framework.test_framework import ExodusTestFramework
 from test_framework.util import (
     assert_equal,
@@ -25,7 +23,7 @@ class ExodusWalletRecoveryTest(ExodusTestFramework):
 
     def clear_datadir(self, node = 0):
         datadir = self.get_datadir(node)
-        shutil.rmtree(datadir)
+        rmtree(datadir)
         os.mkdir(datadir)
 
     def connect_to_other(self, node = 0):

--- a/qa/rpc-tests/transactions_verification_after_restart.py
+++ b/qa/rpc-tests/transactions_verification_after_restart.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 import time
-from decimal import *
+from decimal import getcontext
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-
-from pprint import pprint
+from test_framework.util import bitcoind_processes, enable_mocktime, start_node, start_nodes
 
 # Zapwallettxes, rescan, reindex, reindex-chainstate are not affect existing transactions
 

--- a/qa/rpc-tests/transactions_verification_after_restart.py
+++ b/qa/rpc-tests/transactions_verification_after_restart.py
@@ -20,15 +20,15 @@ from pprint import pprint
 #8. 2 Spend in different time
 #9. Send
 #10. Restart with zapwallettxes=1
-#11. Check all transactions shown properly as before restart 
+#11. Check all transactions shown properly as before restart
 #12. Restart with zapwallettxes=2
-#13. Check all transactions shown properly as before restart 
+#13. Check all transactions shown properly as before restart
 #14. Restart with rescan
-#15. Check all transactions shown properly as before restart 
+#15. Check all transactions shown properly as before restart
 #16. Restart with reindex
-#17. Check all transactions shown properly as before restart 
+#17. Check all transactions shown properly as before restart
 #18. Restart with reindex-chainstate
-#19. Check all transactions shown properly as before restart 
+#19. Check all transactions shown properly as before restart
 
 class TransactionsVerAfterRestartTest(BitcoinTestFramework):
     def __init__(self):
@@ -96,27 +96,27 @@ class TransactionsVerAfterRestartTest(BitcoinTestFramework):
 
         self.nodes[0].stop()
         bitcoind_processes[0].wait()
-        
+
         #10. Restart with zapwallettxes=1
         self.nodes[0] = start_node(0,self.options.tmpdir, ["-zapwallettxes=1"])
 
         #list of transactions should be same as initial after restart with flag
         transactions_after_zapwallettxes1 = self.nodes[0].listtransactions()
 
-        #11. Check all transactions shown properly as before restart 
+        #11. Check all transactions shown properly as before restart
         assert transactions_before == transactions_after_zapwallettxes1, \
             'List of transactions after restart with zapwallettxes=1 unexpectedly changed.'
-        
+
         self.nodes[0].stop()
         bitcoind_processes[0].wait()
-        
+
         #12. Restart with zapwallettxes=2
         self.nodes[0] = start_node(0,self.options.tmpdir, ["-zapwallettxes=2"])
-        
+
         #list of transactions should be same as initial after restart with flag
         transactions_after_zapwallettxes2 = self.nodes[0].listtransactions()
 
-        #13. Check all transactions shown properly as before restart 
+        #13. Check all transactions shown properly as before restart
         assert transactions_before == transactions_after_zapwallettxes2, \
             'List of transactions after restart with zapwallettxes=2 unexpectedly changed.'
 
@@ -125,8 +125,8 @@ class TransactionsVerAfterRestartTest(BitcoinTestFramework):
 
         #14. Restart with rescan
         self.nodes[0] = start_node(0,self.options.tmpdir, ["-rescan"])
-        
-        #15. Check all transactions shown properly as before restart 
+
+        #15. Check all transactions shown properly as before restart
         transactions_after_rescan = self.nodes[0].listtransactions()
 
         assert transactions_before == transactions_after_rescan, \
@@ -158,7 +158,7 @@ class TransactionsVerAfterRestartTest(BitcoinTestFramework):
         self.nodes[0] = start_node(0,self.options.tmpdir, ["-reindex-chainstate"])
 
         time.sleep(5)
-        
+
         #19. Check all transactions shown properly as before restart
         tx_after_reindex_chainstate = sorted(self.nodes[0].listtransactions("*", 1000), key=lambda k: k['txid'], reverse=True)
 


### PR DESCRIPTION
## PR intention
Add test to make sure exodus sigma mint which is created before encrypting wallet can be spend later.

## Code changes brief
Steps to test
1) Create property with sigma feature
2) mint some exodus sigma and sigma.
3) encrypt wallet
4) try to spend should fail
5) unlock wallet and try to spend again, should success

closes https://github.com/zcoinofficial/zcoin/issues/712