### PR TITLE
Fix runtime Qt signal errors

### DIFF
--- a/src/qt/elyassetsdialog.cpp
+++ b/src/qt/elyassetsdialog.cpp
@@ -118,7 +118,7 @@ ElyAssetsDialog::~ElyAssetsDialog()
     delete ui;
 }
 
-void ElyAssetsDialog::reinitOmni()
+void ElyAssetsDialog::reinitEly()
 {
     ui->propSelectorWidget->clear();
     ui->balancesTable->setRowCount(0);
@@ -130,8 +130,8 @@ void ElyAssetsDialog::setClientModel(ClientModel *model)
 {
     this->clientModel = model;
     if (model != NULL) {
-        connect(model, SIGNAL(refreshOmniBalance()), this, SLOT(balancesUpdated()));
-        connect(model, SIGNAL(reinitOmniState()), this, SLOT(reinitOmni()));
+        connect(model, SIGNAL(refreshElysiumBalance()), this, SLOT(balancesUpdated()));
+        connect(model, SIGNAL(reinitElysiumState()), this, SLOT(reinitEly()));
     }
 }
 

--- a/src/qt/elyassetsdialog.h
+++ b/src/qt/elyassetsdialog.h
@@ -51,7 +51,7 @@ private:
 public Q_SLOTS:
     void propSelectorChanged();
     void balancesUpdated();
-    void reinitOmni();
+    void reinitEly();
 
 private Q_SLOTS:
     void contextualMenu(const QPoint &point);

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -53,6 +53,9 @@ public Q_SLOTS:
 Q_SIGNALS:
     void transactionClicked(const QModelIndex &index);
     void enabledTorChanged();
+#ifdef ENABLE_ELYSIUM
+    void elysiumTransactionClicked(const uint256& txid);
+#endif
 
 private:
     Ui::OverviewPage *ui;

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -53,7 +53,6 @@ public Q_SLOTS:
 Q_SIGNALS:
     void transactionClicked(const QModelIndex &index);
     void enabledTorChanged();
-    void elysiumTransactionClicked(const uint256& txid);
 
 private:
     Ui::OverviewPage *ui;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -665,7 +665,6 @@ void RPCConsole::startExecutor()
     connect(this, SIGNAL(stopExecutor()), &thread, SLOT(quit()));
     // - queue executor for deletion (in execution thread)
     connect(&thread, SIGNAL(finished()), executor, SLOT(deleteLater()), Qt::DirectConnection);
-    connect(&thread, SIGNAL(finished()), this, SLOT(test()), Qt::DirectConnection);
 
     // Default implementation of QThread::run() simply spins up an event loop in the thread,
     // which is what we want.

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -111,10 +111,6 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *platformStyle, QWidget *pa
 void SendCoinsDialog::setClientModel(ClientModel *clientModel)
 {
     this->clientModel = clientModel;
-
-    if (clientModel) {
-        connect(clientModel, SIGNAL(numBlocksChanged(int,QDateTime,double,bool)), this, SLOT(updateSmartFeeLabel()));
-    }
 }
 
 void SendCoinsDialog::setModel(WalletModel *model)
@@ -603,32 +599,6 @@ void SendCoinsDialog::updateMinFeeLabel()
             BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), CWallet::GetRequiredFee(1000)) + "/kB")
         );
 }
-
-//void SendCoinsDialog::updateSmartFeeLabel()
-//{
-//    if(!model || !model->getOptionsModel())
-//        return;
-
-//    int nBlocksToConfirm = defaultConfirmTarget - ui->sliderSmartFee->value();
-//    int estimateFoundAtBlocks = nBlocksToConfirm;
-//    CFeeRate feeRate = mempool.estimateSmartFee(nBlocksToConfirm, &estimateFoundAtBlocks);
-//    if (feeRate <= CFeeRate(0)) // not enough data => minfee
-//    {
-//        ui->labelSmartFee->setText(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(),
-//                                                                std::max(CWallet::fallbackFee.GetFeePerK(), CWallet::GetRequiredFee(1000))) + "/kB");
-//        ui->labelSmartFee2->show(); // (Smart fee not initialized yet. This usually takes a few blocks...)
-//        ui->labelFeeEstimation->setText("");
-//    }
-//    else
-//    {
-//        ui->labelSmartFee->setText(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(),
-//                                                                std::max(feeRate.GetFeePerK(), CWallet::GetRequiredFee(1000))) + "/kB");
-//        ui->labelSmartFee2->hide();
-//        ui->labelFeeEstimation->setText(tr("Estimated to begin confirmation within %n block(s).", "", estimateFoundAtBlocks));
-//    }
-
-//    updateFeeMinimizedLabel();
-//}
 
 // Coin Control: copy label "Quantity" to clipboard
 void SendCoinsDialog::coinControlClipboardQuantity()

--- a/src/qt/sendmpdialog.cpp
+++ b/src/qt/sendmpdialog.cpp
@@ -91,8 +91,8 @@ void SendMPDialog::setClientModel(ClientModel *model)
 {
     this->clientModel = model;
     if (model != NULL) {
-        connect(model, SIGNAL(refreshOmniBalance()), this, SLOT(balancesUpdated()));
-        connect(model, SIGNAL(reinitOmniState()), this, SLOT(balancesUpdated()));
+        connect(model, SIGNAL(refreshElysiumBalance()), this, SLOT(balancesUpdated()));
+        connect(model, SIGNAL(reinitElysiumState()), this, SLOT(balancesUpdated()));
     }
 }
 

--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -164,7 +164,7 @@ void TXHistoryDialog::setClientModel(ClientModel *model)
     this->clientModel = model;
     if (model != NULL) {
         connect(model, SIGNAL(refreshElysiumBalance()), this, SLOT(UpdateHistory()));
-        connect(model, SIGNAL(numBlocksChanged(int)), this, SLOT(UpdateConfirmations()));
+        connect(model, SIGNAL(numBlocksChanged(int,QDateTime,double,bool)), this, SLOT(UpdateConfirmations()));
         connect(model, SIGNAL(reinitElysiumState()), this, SLOT(ReinitTXHistoryTable()));
     }
 }

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -107,7 +107,6 @@ WalletView::WalletView(const PlatformStyle *platformStyle, QWidget *parent):
 
     // Clicking on a transaction on the overview pre-selects the transaction on the transaction history page
     connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), this, SLOT(focusBitcoinHistoryTab(QModelIndex)));
-    connect(overviewPage, SIGNAL(elysiumTransactionClicked(uint256)), this, SLOT(focusElysiumTransaction(uint256)));
 }
 
 WalletView::~WalletView()
@@ -244,7 +243,6 @@ void WalletView::setBitcoinGUI(BitcoinGUI *gui)
     {
         // Clicking on a transaction on the overview page simply sends you to transaction history page
         connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), gui, SLOT(gotoBitcoinHistoryTab()));
-        connect(overviewPage, SIGNAL(elysiumTransactionClicked(uint256)), gui, SLOT(gotoElysiumHistoryTab()));
 
         // Receive and report messages
         connect(this, SIGNAL(message(QString,QString,unsigned int)), gui, SLOT(message(QString,QString,unsigned int)));

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -107,6 +107,9 @@ WalletView::WalletView(const PlatformStyle *platformStyle, QWidget *parent):
 
     // Clicking on a transaction on the overview pre-selects the transaction on the transaction history page
     connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), this, SLOT(focusBitcoinHistoryTab(QModelIndex)));
+#ifdef ENABLE_ELYSIUM
+    connect(overviewPage, SIGNAL(elysiumTransactionClicked(uint256)), this, SLOT(focusElysiumTransaction(uint256)));
+#endif
 }
 
 WalletView::~WalletView()
@@ -243,6 +246,9 @@ void WalletView::setBitcoinGUI(BitcoinGUI *gui)
     {
         // Clicking on a transaction on the overview page simply sends you to transaction history page
         connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), gui, SLOT(gotoBitcoinHistoryTab()));
+#ifdef ENABLE_ELYSIUM
+        connect(overviewPage, SIGNAL(elysiumTransactionClicked(uint256)), gui, SLOT(gotoElysiumHistoryTab()));
+#endif
 
         // Receive and report messages
         connect(this, SIGNAL(message(QString,QString,unsigned int)), gui, SLOT(message(QString,QString,unsigned int)));

--- a/src/qt/znodelist.cpp
+++ b/src/qt/znodelist.cpp
@@ -82,10 +82,6 @@ ZnodeList::~ZnodeList()
 void ZnodeList::setClientModel(ClientModel *model)
 {
     this->clientModel = model;
-    if(model) {
-        // try to update list when znode count changes
-        connect(clientModel, SIGNAL(strZnodesChanged(QString)), this, SLOT(updateNodeList()));
-    }
 }
 
 void ZnodeList::setWalletModel(WalletModel *model)


### PR DESCRIPTION
Fixes https://github.com/zcoinofficial/zcoin/issues/417

## PR intention
The following errors related to Qt signals are only output at runtime (with Elysium enabled):
```
GUI: QObject::connect: No such slot WalletView::focusElysiumTransaction(uint256) in qt/walletview.cpp:112
GUI: QObject::connect:  (sender name:   'OverviewPage')
GUI: QObject::connect: No such slot BitcoinGUI::gotoElysiumHistoryTab() in qt/walletview.cpp:252
GUI: QObject::connect:  (sender name:   'OverviewPage')
GUI: QObject::connect: No such signal ClientModel::refreshOmniBalance() in qt/elyassetsdialog.cpp:133
GUI: QObject::connect:  (receiver name: 'ElyAssetsDialog')
GUI: QObject::connect: No such signal ClientModel::reinitOmniState() in qt/elyassetsdialog.cpp:134
GUI: QObject::connect:  (receiver name: 'ElyAssetsDialog')
GUI: QObject::connect: No such slot SendCoinsDialog::updateSmartFeeLabel() in qt/sendcoinsdialog.cpp:121
GUI: QObject::connect:  (receiver name: 'SendCoinsDialog')
GUI: QObject::connect: No such signal ClientModel::strZnodesChanged(QString) in qt/znodelist.cpp:87
GUI: QObject::connect:  (receiver name: 'ZnodeList')
GUI: QObject::connect: No such slot RPCConsole::test() in qt/rpcconsole.cpp:668
GUI: QObject::connect:  (receiver name: 'RPCConsole')
```
Remove the unnecessary signals and include the valid ones. 

## Code changes brief
- The first two are related to Elysium - a signal was implemented that was never called. From looking at the Omni code, this was eventually removed, so I've removed it here.

- `refreshOmniBalance()` & `reinitOmniState()` were never renamed to `Elysium`, this fixes the error

- In `znodelist.cpp` a signal is setup with no implementation. As this has no effect, has not affected the Qt experience, and also that we are soon moving away from this Znode screen, this can be removed.

- In `sendcoinsdialog.cpp`, a function linked to a signal, `updateSmartFeeLabel()`, doesn't exist. The function is commented out in this file. Again as it has had no effect, I think it can be removed.

- In `rpcconsole.cpp`, a signal called `test()` was added which has no effect, so this was also removed.