### PR TITLE
Adding libgmp-dev into the Docker image

### DIFF
--- a/contrib/docker/builder/Dockerfile
+++ b/contrib/docker/builder/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     autoconf automake bsdmainutils ccache cmake curl g++ g++-mingw-w64-x86-64 gcc gcc-mingw-w64-x86-64 git \
     libboost-all-dev libbz2-dev libcap-dev libdb4.8-dev libdb4.8++-dev libevent-dev libminiupnpc-dev libprotobuf-dev \
     libqrencode-dev libssl-dev libtool make pkg-config protobuf-compiler python-pip qtbase5-dev \
-    qttools5-dev-tools python3-zmq zlib1g-dev build-essential minizip lcov default-jre libzmq3-dev
+    qttools5-dev-tools python3-zmq zlib1g-dev build-essential minizip lcov default-jre libzmq3-dev libgmp-dev
 
 RUN pip install ez_setup
 


### PR DESCRIPTION
## PR intention
libgmp-dev is required for core14 to be built.
