### PR TITLE
Core14 changes

### DIFF
--- a/src/hdmint/tracker.cpp
+++ b/src/hdmint/tracker.cpp
@@ -516,7 +516,7 @@ bool CHDMintTracker::UpdateMetaStatus(const std::set<uint256>& setMempool, CMint
  */
 void CHDMintTracker::UpdateFromBlock(const std::list<std::pair<uint256, MintPoolEntry>>& mintPoolEntries, const std::vector<CMintMeta>& updatedMeta){
     if (mintPoolEntries.size() > 0) {
-        zwalletMain->SyncWithChain(false, mintPoolEntries);
+        pwalletMain->zwallet->SyncWithChain(false, mintPoolEntries);
     }
 
     //overwrite any updates

--- a/src/hdmint/tracker.h
+++ b/src/hdmint/tracker.h
@@ -7,6 +7,7 @@
 
 #include "primitives/zerocoin.h"
 #include "hdmint/mintpool.h"
+#include "wallet/walletdb.h"
 #include <list>
 
 class CHDMint;
@@ -25,8 +26,8 @@ private:
 public:
     CHDMintTracker(std::string strWalletFile);
     ~CHDMintTracker();
-    void Add(const CHDMint& dMint, bool isNew = false, bool isArchived = false);
-    void Add(const CSigmaEntry& sigma, bool isNew = false, bool isArchived = false);
+    void Add(CWalletDB& walletdb, const CHDMint& dMint, bool isNew = false, bool isArchived = false);
+    void Add(CWalletDB& walletdb, const CSigmaEntry& sigma, bool isNew = false, bool isArchived = false);
     bool Archive(CMintMeta& meta);
     bool HasPubcoinHash(const uint256& hashPubcoin) const;
     bool HasSerialHash(const uint256& hashSerial) const;

--- a/src/hdmint/wallet.cpp
+++ b/src/hdmint/wallet.cpp
@@ -520,7 +520,7 @@ CKeyID CHDMintWallet::GetMintSeedID(CWalletDB& walletdb, int32_t nCount){
  * @param seedId (optional) seedId of the key to use for mint generation.
  * @return sucess
  */
-bool CHDMintWallet::CreateMintSeed(CWalletDB& walletdb, uint512& mintSeed, const int32_t& nCount, CKeyID& seedId, bool nWriteChain)
+bool CHDMintWallet::CreateMintSeed(CWalletDB& walletdb, uint512& mintSeed, const int32_t& nCount, CKeyID& seedId, bool fWriteChain)
 {
     LOCK(pwalletMain->cs_wallet);
     CKey key;
@@ -530,7 +530,7 @@ bool CHDMintWallet::CreateMintSeed(CWalletDB& walletdb, uint512& mintSeed, const
         int32_t chainIndex = pwalletMain->GetHDChain().nExternalChainCounters[BIP44_MINT_INDEX];
         if(nCount==chainIndex){
             // If chainIndex is the same as n (ie. we are generating next available key), generate a new key.
-            pubKey = pwalletMain->GenerateNewKey(BIP44_MINT_INDEX, nWriteChain);
+            pubKey = pwalletMain->GenerateNewKey(BIP44_MINT_INDEX, fWriteChain);
         }
         else if(nCount<chainIndex){
             // if it's less than the current chain index, we are regenerating the mintpool. get the key at n

--- a/src/hdmint/wallet.h
+++ b/src/hdmint/wallet.h
@@ -20,7 +20,7 @@ class CHDMintWallet
 private:
     int32_t nCountNextUse;
     int32_t nCountNextGenerate;
-    std::string strWalletFile;
+    CWalletDB walletdb;
     CMintPool mintPool;
     CHDMintTracker tracker;
     uint160 hashSeedMaster;
@@ -50,7 +50,6 @@ public:
     void SetCount(int32_t nCount);
     void UpdateCountLocal();
     void UpdateCountDB();
-    void UpdateCount();
     void SetWalletTransactionBlock(CWalletTx &wtx, const CBlockIndex *blockIndex, const CBlock &block);
 
 private:

--- a/src/hdmint/wallet.h
+++ b/src/hdmint/wallet.h
@@ -20,7 +20,7 @@ class CHDMintWallet
 private:
     int32_t nCountNextUse;
     int32_t nCountNextGenerate;
-    CWalletDB walletdb;
+    const std::string& strWalletFile;
     CMintPool mintPool;
     CHDMintTracker tracker;
     uint160 hashSeedMaster;
@@ -32,29 +32,29 @@ public:
 
     bool SetupWallet(const uint160& hashSeedMaster, bool fResetCount=false);
     void SyncWithChain(bool fGenerateMintPool = true, boost::optional<std::list<std::pair<uint256, MintPoolEntry>>> listMints = boost::none);
-    bool GetHDMintFromMintPoolEntry(const sigma::CoinDenomination denom, sigma::PrivateCoin& coin, CHDMint& dMint, MintPoolEntry& mintPoolEntry);
-    bool GenerateMint(const sigma::CoinDenomination denom, sigma::PrivateCoin& coin, CHDMint& dMint, boost::optional<MintPoolEntry> mintPoolEntry = boost::none, bool fAllowUnsynced=false);
+    bool GetHDMintFromMintPoolEntry(CWalletDB& walletdb, const sigma::CoinDenomination denom, sigma::PrivateCoin& coin, CHDMint& dMint, MintPoolEntry& mintPoolEntry);
+    bool GenerateMint(CWalletDB& walletdb, const sigma::CoinDenomination denom, sigma::PrivateCoin& coin, CHDMint& dMint, boost::optional<MintPoolEntry> mintPoolEntry = boost::none, bool fAllowUnsynced=false);
     bool LoadMintPoolFromDB();
-    bool RegenerateMint(const CHDMint& dMint, CSigmaEntry& sigma);
+    bool RegenerateMint(CWalletDB& walletdb, const CHDMint& dMint, CSigmaEntry& sigma);
     bool GetSerialForPubcoin(const std::vector<std::pair<uint256, GroupElement>>& serialPubcoinPairs, const uint256& hashPubcoin, uint256& hashSerial);
     bool IsSerialInBlockchain(const uint256& hashSerial, int& nHeightTx, uint256& txidSpend, CTransactionRef tx);
     bool TxOutToPublicCoin(const CTxOut& txout, sigma::PublicCoin& pubCoin, CValidationState& state);
-    std::pair<uint256,uint256> RegenerateMintPoolEntry(const uint160& mintHashSeedMaster, CKeyID& seedId, const int32_t& nCount);
-    void GenerateMintPool(int32_t nIndex = 0);
-    bool SetMintSeedSeen(std::pair<uint256,MintPoolEntry> mintPoolEntryPair, const int& nHeight, const uint256& txid, const sigma::CoinDenomination& denom);
+    std::pair<uint256,uint256> RegenerateMintPoolEntry(CWalletDB& walletdb, const uint160& mintHashSeedMaster, CKeyID& seedId, const int32_t& nCount);
+    void GenerateMintPool(CWalletDB& walletdb, int32_t nIndex = 0);
+    bool SetMintSeedSeen(CWalletDB& walletdb, std::pair<uint256,MintPoolEntry> mintPoolEntryPair, const int& nHeight, const uint256& txid, const sigma::CoinDenomination& denom);
     bool SeedToMint(const uint512& mintSeed, GroupElement& bnValue, sigma::PrivateCoin& coin);
     // Count updating functions
     int32_t GetCount();
     CHDMintTracker& GetTracker() { return tracker; }
-    void ResetCount();
+    void ResetCount(CWalletDB& walletdb);
     void SetCount(int32_t nCount);
     void UpdateCountLocal();
-    void UpdateCountDB();
+    void UpdateCountDB(CWalletDB& walletdb);
     void SetWalletTransactionBlock(CWalletTx &wtx, const CBlockIndex *blockIndex, const CBlock &block);
 
 private:
-    CKeyID GetMintSeedID(int32_t nCount);
-    bool CreateMintSeed(uint512& mintSeed, const int32_t& n, CKeyID& seedId);
+    CKeyID GetMintSeedID(CWalletDB& walletdb, int32_t nCount);
+    bool CreateMintSeed(CWalletDB& walletdb, uint512& mintSeed, const int32_t& n, CKeyID& seedId, bool nWriteChain = true);
 };
 
 #endif //ZCOIN_HDMINTWALLET_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -267,8 +267,8 @@ void Shutdown()
 #ifdef ENABLE_WALLET
     if (pwalletMain)
         pwalletMain->Flush(false);
-    delete zwalletMain;
-    zwalletMain = NULL;
+    delete pwalletMain->zwallet;
+    pwalletMain->zwallet = NULL;
 #endif
     GenerateBitcoins(false, 0, Params());
     CFlatDB<CZnodeMan> flatdb1("zncache.dat", "magicZnodeCache");
@@ -344,8 +344,8 @@ void Shutdown()
 #ifdef ENABLE_WALLET
     if (pwalletMain)
         pwalletMain->Flush(true);
-    delete zwalletMain;
-    zwalletMain = NULL;
+    delete pwalletMain->zwallet;
+    pwalletMain->zwallet = NULL;
 #endif
 
 #if ENABLE_ZMQ
@@ -748,11 +748,11 @@ void CleanupBlockRevFiles()
 void ThreadImport(std::vector <boost::filesystem::path> vImportFiles) {
 
 #ifdef ENABLE_WALLET
-    if (!GetBoolArg("-disablewallet", false) && zwalletMain) {
+    if (!GetBoolArg("-disablewallet", false) && pwalletMain->zwallet) {
         //Load zerocoin mint hashes to memory
         LogPrintf("Loading mints to wallet..\n");
-        zwalletMain->GetTracker().Init();
-        zwalletMain->LoadMintPoolFromDB();
+        pwalletMain->zwallet->GetTracker().Init();
+        pwalletMain->zwallet->LoadMintPoolFromDB();
     }
 #endif
 
@@ -844,12 +844,12 @@ void ThreadImport(std::vector <boost::filesystem::path> vImportFiles) {
     }
 
 #ifdef ENABLE_WALLET
-    if (!GetBoolArg("-disablewallet", false) && zwalletMain) {
-        zwalletMain->SyncWithChain();
+    if (!GetBoolArg("-disablewallet", false) && pwalletMain->zwallet) {
+        pwalletMain->zwallet->SyncWithChain();
     }
     // Need this to restore Sigma spend state
-    if (GetBoolArg("-rescan", false) && zwalletMain) {
-        zwalletMain->GetTracker().ListMints();
+    if (GetBoolArg("-rescan", false) && pwalletMain->zwallet) {
+        pwalletMain->zwallet->GetTracker().ListMints();
     }
 #endif
     fDumpMempoolLater = !fRequestShutdown;
@@ -1908,7 +1908,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     LogPrintf("Step 8: load wallet ************************************\n");
     if (GetBoolArg("-disablewallet", false)) {
         pwalletMain = NULL;
-        zwalletMain = NULL;
+        pwalletMain->zwallet = NULL;
         LogPrintf("Wallet disabled!\n");
     } else {
     CWallet::InitLoadWallet();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -267,8 +267,6 @@ void Shutdown()
 #ifdef ENABLE_WALLET
     if (pwalletMain)
         pwalletMain->Flush(false);
-    delete pwalletMain->zwallet;
-    pwalletMain->zwallet = NULL;
 #endif
     GenerateBitcoins(false, 0, Params());
     CFlatDB<CZnodeMan> flatdb1("zncache.dat", "magicZnodeCache");
@@ -344,8 +342,6 @@ void Shutdown()
 #ifdef ENABLE_WALLET
     if (pwalletMain)
         pwalletMain->Flush(true);
-    delete pwalletMain->zwallet;
-    pwalletMain->zwallet = NULL;
 #endif
 
 #if ENABLE_ZMQ
@@ -848,7 +844,7 @@ void ThreadImport(std::vector <boost::filesystem::path> vImportFiles) {
         pwalletMain->zwallet->SyncWithChain();
     }
     // Need this to restore Sigma spend state
-    if (GetBoolArg("-rescan", false) && pwalletMain->zwallet) {
+    if (GetBoolArg("-rescan", false) && !GetBoolArg("-disablewallet", false) && pwalletMain->zwallet) {
         pwalletMain->zwallet->GetTracker().ListMints();
     }
 #endif
@@ -1908,7 +1904,6 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     LogPrintf("Step 8: load wallet ************************************\n");
     if (GetBoolArg("-disablewallet", false)) {
         pwalletMain = NULL;
-        pwalletMain->zwallet = NULL;
         LogPrintf("Wallet disabled!\n");
     } else {
     CWallet::InitLoadWallet();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -143,7 +143,7 @@ void WalletModel::pollBalanceChanged()
 
         // check sigma
         // support only hd
-        if (zwalletMain) {
+        if (wallet->zwallet) {
             checkSigmaAmount(false);
         }
     }
@@ -159,7 +159,7 @@ void WalletModel::updateSigmaCoins(const QString &pubCoin, const QString &isUsed
     } else if (status == ChangeType::CT_NEW) {
         // new mint
         LOCK2(cs_main, wallet->cs_wallet);
-        auto coins = zwalletMain->GetTracker().ListMints(true, false, false);
+        auto coins = wallet->zwallet->GetTracker().ListMints(true, false, false);
 
         int block = cachedNumBlocks;
         for (const auto& coin : coins) {
@@ -214,7 +214,7 @@ void WalletModel::checkSigmaAmount(bool forced)
         || currentBlock < lastBlockCheckSigma // reorg
         || forced) {
 
-        auto coins = zwalletMain->GetTracker().ListMints(true, false, false);
+        auto coins = wallet->zwallet->GetTracker().ListMints(true, false, false);
 
         std::vector<CMintMeta> spendable, pending;
 
@@ -570,7 +570,7 @@ static void NotifyZerocoinChanged(WalletModel *walletmodel, CWallet *wallet, con
                               Q_ARG(int, status));
 
     // disable sigma
-    if (zwalletMain) {
+    if (wallet->zwallet) {
         QMetaObject::invokeMethod(walletmodel, "updateSigmaCoins", Qt::QueuedConnection,
                               Q_ARG(QString, QString::fromStdString(pubCoin)),
                               Q_ARG(QString, QString::fromStdString(isUsed)),

--- a/src/test/hdmint_tests.cpp
+++ b/src/test/hdmint_tests.cpp
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(deterministic)
         BOOST_CHECK_MESSAGE(mempool.size() == ++mempoolCount, "Mint tx was not added to mempool");
 
         // Verify correct mint count
-        BOOST_CHECK(mintCount == zwalletMain->GetCount());
+        BOOST_CHECK(mintCount == pwalletMain->zwallet->GetCount());
 
         for(auto& mint : vDMintsBuilder){
             vDMints.push_back(mint);
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(deterministic)
     // Clear HDMints in db and sigma state (to allow regeneration of the same mints)
 
     CWalletDB walletdb(pwalletMain->strWalletFile);
-    zwalletMain->SetCount(0);
+    pwalletMain->zwallet->SetCount(0);
     mintCount = 0;
     sigmaState->Reset();
     pwalletMain->ZapSigmaMints();
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(deterministic)
             stringError, denominationPairs, vDMintsBuilder, SIGMA), stringError + " - Create Mint failed");
 
         // Verify correct mint count
-        BOOST_CHECK(mintCount == zwalletMain->GetCount());
+        BOOST_CHECK(mintCount == pwalletMain->zwallet->GetCount());
 
         for(auto& mint : vDMintsBuilder){
             vDMintsRegenerated.push_back(mint);
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(wallet_count)
         BOOST_CHECK(strError == "");
     }
 
-    zwalletMain->SetCount(0); // reset count
+    pwalletMain->zwallet->SetCount(0); // reset count
 
     // create another mint
     CAmount nAmount = AmountFromValue("1");
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(wallet_count)
     auto vecSend = CWallet::CreateSigmaMintRecipients(privCoins, vDMints);
 
     BOOST_CHECK(vDMints[0].GetCount() == TOTAL_MINTS);
-    BOOST_CHECK(zwalletMain->GetCount() == (TOTAL_MINTS+1));
+    BOOST_CHECK(pwalletMain->zwallet->GetCount() == (TOTAL_MINTS+1));
 
 }
 
@@ -290,7 +290,7 @@ BOOST_AUTO_TEST_CASE(blockchain_restore)
         BOOST_CHECK_MESSAGE(mempool.size() == 1, "Mint tx was not added to mempool");
 
         // Verify correct mint count
-        BOOST_CHECK(mintCount == zwalletMain->GetCount());
+        BOOST_CHECK(mintCount == pwalletMain->zwallet->GetCount());
 
         for(auto& mint : vDMintsBuilder){
             vDMints.push_back(mint);
@@ -316,16 +316,16 @@ BOOST_AUTO_TEST_CASE(blockchain_restore)
     uint256 hashPubcoin;
     for (auto& mintPoolPair : listMintPool){
         hashPubcoin = mintPoolPair.first;
-        zwalletMain->GetSerialForPubcoin(serialPubcoinPairs, hashPubcoin, hashSerial);
+        pwalletMain->zwallet->GetSerialForPubcoin(serialPubcoinPairs, hashPubcoin, hashSerial);
         walletdb.EraseMintPoolPair(hashPubcoin);
         walletdb.ErasePubcoin(hashSerial);
     }
 
-    // Start zwalletMain from scratch
-    zwalletMain = new CHDMintWallet(pwalletMain->strWalletFile, true);
+    // Start pwalletMain->zwallet from scratch
+    pwalletMain->zwallet = new CHDMintWallet(pwalletMain->strWalletFile, true);
 
     // sync mints with chain (will regenerate mintpool + sync with chain)
-    zwalletMain->SyncWithChain();
+    pwalletMain->zwallet->SyncWithChain();
 
     // Pull mints from the wallet
     std::list<CHDMint> vDMintsRegeneratedList = walletdb.ListHDMints();

--- a/src/test/hdmint_tests.cpp
+++ b/src/test/hdmint_tests.cpp
@@ -322,7 +322,7 @@ BOOST_AUTO_TEST_CASE(blockchain_restore)
     }
 
     // Start pwalletMain->zwallet from scratch
-    pwalletMain->zwallet = new CHDMintWallet(pwalletMain->strWalletFile, true);
+    pwalletMain->zwallet = std::make_unique<CHDMintWallet>(pwalletMain->strWalletFile, true);
 
     // sync mints with chain (will regenerate mintpool + sync with chain)
     pwalletMain->zwallet->SyncWithChain();

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -126,10 +126,10 @@ TestingSetup::TestingSetup(const std::string& chainName, std::string suf) : Basi
 
         pwalletMain->SetBestChain(chainActive.GetLocator());
 
-        zwalletMain = new CHDMintWallet(pwalletMain->strWalletFile);
-        zwalletMain->GetTracker().Init();
-        zwalletMain->LoadMintPoolFromDB();
-        zwalletMain->SyncWithChain();
+        pwalletMain->zwallet = new CHDMintWallet(pwalletMain->strWalletFile);
+        pwalletMain->zwallet->GetTracker().Init();
+        pwalletMain->zwallet->LoadMintPoolFromDB();
+        pwalletMain->zwallet->SyncWithChain();
 }
 
 TestingSetup::~TestingSetup()

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -126,7 +126,7 @@ TestingSetup::TestingSetup(const std::string& chainName, std::string suf) : Basi
 
         pwalletMain->SetBestChain(chainActive.GetLocator());
 
-        pwalletMain->zwallet = new CHDMintWallet(pwalletMain->strWalletFile);
+        pwalletMain->zwallet = std::make_unique<CHDMintWallet>(pwalletMain->strWalletFile);
         pwalletMain->zwallet->GetTracker().Init();
         pwalletMain->zwallet->LoadMintPoolFromDB();
         pwalletMain->zwallet->SyncWithChain();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1325,16 +1325,16 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
             sigmaState->AddSpendToMempool(zcSpendSerialsV3, hash);
         LogPrintf("Updating mint tracker state from Mempool..");
 #ifdef ENABLE_WALLET
-        if (zwalletMain) {
+        if (pwalletMain->zwallet) {
             LogPrintf("Updating spend state from Mempool..");
-            zwalletMain->GetTracker().UpdateSpendStateFromMempool(zcSpendSerialsV3);
+            pwalletMain->zwallet->GetTracker().UpdateSpendStateFromMempool(zcSpendSerialsV3);
         }
 #endif
     }
     if(markZcoinSpendTransactionSerial)
         sigmaState->AddMintsToMempool(zcMintPubcoinsV3);
 #ifdef ENABLE_WALLET
-    if(tx.IsSigmaMint() && zwalletMain) {
+    if(tx.IsSigmaMint() && pwalletMain->zwallet) {
         LogPrintf("Updating mint state from Mempool..");
         zwalletMain->GetTracker().UpdateMintStateFromMempool(zcMintPubcoinsV3);
     }
@@ -2953,13 +2953,13 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
 
 #ifdef ENABLE_WALLET
     // update mint/spend wallet
-    if (zwalletMain) {
+    if (pwalletMain->zwallet) {
         if (block.sigmaTxInfo->spentSerials.size() > 0) {
-            zwalletMain->GetTracker().UpdateSpendStateFromBlock(block.sigmaTxInfo->spentSerials);
+            pwalletMain->zwallet->GetTracker().UpdateSpendStateFromBlock(block.sigmaTxInfo->spentSerials);
         }
 
         if (block.sigmaTxInfo->mints.size() > 0) {
-            zwalletMain->GetTracker().UpdateMintStateFromBlock(block.sigmaTxInfo->mints);
+            pwalletMain->zwallet->GetTracker().UpdateMintStateFromBlock(block.sigmaTxInfo->mints);
         }
     }
 #endif
@@ -3092,16 +3092,16 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
 
 #ifdef ENABLE_WALLET
     // Sync with HDMint wallet
-    if (zwalletMain && blockConnecting.sigmaTxInfo) {
+    if (pwalletMain->zwallet && blockConnecting.sigmaTxInfo) {
         LogPrintf("Checking if block contains wallet mints..\n");
         if (blockConnecting.sigmaTxInfo->spentSerials.size() > 0) {
             LogPrintf("HDmint: UpdateSpendStateFromBlock. [height: %d]\n", GetHeight());
-            zwalletMain->GetTracker().UpdateSpendStateFromBlock(blockConnecting.sigmaTxInfo->spentSerials);
+            pwalletMain->zwallet->GetTracker().UpdateSpendStateFromBlock(blockConnecting.sigmaTxInfo->spentSerials);
         }
 
         if (blockConnecting.sigmaTxInfo->mints.size() > 0) {
             LogPrintf("HDmint: UpdateMintStateFromBlock. [height: %d]\n", GetHeight());
-            zwalletMain->GetTracker().UpdateMintStateFromBlock(blockConnecting.sigmaTxInfo->mints);
+            pwalletMain->zwallet->GetTracker().UpdateMintStateFromBlock(blockConnecting.sigmaTxInfo->mints);
         }
     }
 #endif

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1336,7 +1336,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
 #ifdef ENABLE_WALLET
     if(tx.IsSigmaMint() && !GetBoolArg("-disablewallet", false) && pwalletMain->zwallet) {
         LogPrintf("Updating mint state from Mempool..");
-        zwalletMain->GetTracker().UpdateMintStateFromMempool(zcMintPubcoinsV3);
+        pwalletMain->zwallet->GetTracker().UpdateMintStateFromMempool(zcMintPubcoinsV3);
     }
 #endif
     GetMainSignals().SyncTransaction(tx, NULL, CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1325,7 +1325,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
             sigmaState->AddSpendToMempool(zcSpendSerialsV3, hash);
         LogPrintf("Updating mint tracker state from Mempool..");
 #ifdef ENABLE_WALLET
-        if (pwalletMain->zwallet) {
+        if (!GetBoolArg("-disablewallet", false) && pwalletMain->zwallet) {
             LogPrintf("Updating spend state from Mempool..");
             pwalletMain->zwallet->GetTracker().UpdateSpendStateFromMempool(zcSpendSerialsV3);
         }
@@ -1334,7 +1334,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
     if(markZcoinSpendTransactionSerial)
         sigmaState->AddMintsToMempool(zcMintPubcoinsV3);
 #ifdef ENABLE_WALLET
-    if(tx.IsSigmaMint() && pwalletMain->zwallet) {
+    if(tx.IsSigmaMint() && !GetBoolArg("-disablewallet", false) && pwalletMain->zwallet) {
         LogPrintf("Updating mint state from Mempool..");
         zwalletMain->GetTracker().UpdateMintStateFromMempool(zcMintPubcoinsV3);
     }
@@ -2953,7 +2953,7 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
 
 #ifdef ENABLE_WALLET
     // update mint/spend wallet
-    if (pwalletMain->zwallet) {
+    if (!GetBoolArg("-disablewallet", false) && pwalletMain->zwallet) {
         if (block.sigmaTxInfo->spentSerials.size() > 0) {
             pwalletMain->zwallet->GetTracker().UpdateSpendStateFromBlock(block.sigmaTxInfo->spentSerials);
         }
@@ -3092,7 +3092,8 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
 
 #ifdef ENABLE_WALLET
     // Sync with HDMint wallet
-    if (pwalletMain->zwallet && blockConnecting.sigmaTxInfo) {
+
+    if (!GetBoolArg("-disablewallet", false) && pwalletMain->zwallet && blockConnecting.sigmaTxInfo) {
         LogPrintf("Checking if block contains wallet mints..\n");
         if (blockConnecting.sigmaTxInfo->spentSerials.size() > 0) {
             LogPrintf("HDmint: UpdateSpendStateFromBlock. [height: %d]\n", GetHeight());

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -224,12 +224,12 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn, const bool& fF
             return false;
         vMasterKey = vMasterKeyIn;
         fDecryptionThoroughlyChecked = true;
-        if(!fFirstUnlock && zwalletMain){
+        if(!fFirstUnlock && pwalletMain->zwallet){
             auto &hdChain = pwalletMain->GetHDChain();
             uint160 hashSeedMaster = hdChain.masterKeyID;
             pwalletMain->SetHDChain(hdChain, false); // Used to upgrade normal keys to BIP44
-            zwalletMain->SetupWallet(hashSeedMaster, false);
-            zwalletMain->SyncWithChain();
+            pwalletMain->zwallet->SetupWallet(hashSeedMaster, false);
+            pwalletMain->zwallet->SyncWithChain();
         }
     }
     NotifyStatusChanged(this);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -574,7 +574,7 @@ UniValue importwallet(const JSONRPCRequest& request)
             if(!masterKeyID.IsNull() && fHd){
                 // If change component in HD path is 2, this is a mint seed key. Add to mintpool. (Have to call after key addition)
                 if(pwallet->mapKeyMetadata[keyid].nChange.first==2){
-                    pwallet->zwallet->RegenerateMintPoolEntry(hdMasterKeyID, keyid, pwallet->mapKeyMetadata[keyid].nChild.first);
+                    pwallet->zwallet->RegenerateMintPoolEntry(walletdb, hdMasterKeyID, keyid, pwallet->mapKeyMetadata[keyid].nChild.first);
                     fMintUpdate = true;
                 }
             }

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -574,7 +574,7 @@ UniValue importwallet(const JSONRPCRequest& request)
             if(!masterKeyID.IsNull() && fHd){
                 // If change component in HD path is 2, this is a mint seed key. Add to mintpool. (Have to call after key addition)
                 if(pwallet->mapKeyMetadata[keyid].nChange.first==2){
-                    zwalletMain->RegenerateMintPoolEntry(hdMasterKeyID, keyid, pwallet->mapKeyMetadata[keyid].nChild.first);
+                    pwallet->zwallet->RegenerateMintPoolEntry(hdMasterKeyID, keyid, pwallet->mapKeyMetadata[keyid].nChild.first);
                     fMintUpdate = true;
                 }
             }
@@ -594,8 +594,8 @@ UniValue importwallet(const JSONRPCRequest& request)
     pwallet->MarkDirty();
 
     if(fMintUpdate){
-        zwalletMain->SyncWithChain();
-        zwalletMain->GetTracker().ListMints(false, false);
+        pwallet->zwallet->SyncWithChain();
+        pwallet->zwallet->GetTracker().ListMints(false, false);
     }
 
     if (!fGood)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -84,7 +84,7 @@ bool EnsureWalletIsAvailable(CWallet * const pwallet, bool avoidException)
 
 void EnsureSigmaWalletIsAvailable()
 {
-    if (!pwalletMain->zwallet) {
+    if (!pwalletMain || !pwalletMain->zwallet) {
         throw JSONRPCError(RPC_WALLET_ERROR, "sigma mint/spend is not allowed for legacy wallet");
     }
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3760,7 +3760,7 @@ UniValue resetsigmamint(const JSONRPCRequest& request) {
         }
         dMint.SetUsed(false);
         dMint.SetHeight(-1);
-        pwallet->zwallet->GetTracker().Add(dMint, true);
+        pwallet->zwallet->GetTracker().Add(walletdb, dMint, true);
     }
 
     return NullUniValue;
@@ -4075,10 +4075,10 @@ UniValue setsigmamintstatus(const JSONRPCRequest& request) {
 
                 if(!mint.isDeterministic){
                     zerocoinItem.IsUsed = fStatus;
-                    pwallet->zwallet->GetTracker().Add(zerocoinItem, true);
+                    pwallet->zwallet->GetTracker().Add(walletdb, zerocoinItem, true);
                 }else{
                     dMint.SetUsed(fStatus);
-                    pwallet->zwallet->GetTracker().Add(dMint, true);
+                    pwallet->zwallet->GetTracker().Add(walletdb, dMint, true);
                 }
 
                 if (!fStatus) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2958,7 +2958,7 @@ UniValue regeneratemintpool(const JSONRPCRequest& request) {
         bool hasSerial = pwallet->zwallet->GetSerialForPubcoin(serialPubcoinPairs, oldHashPubcoin, oldHashSerial);
 
         MintPoolEntry entry = mintPoolPair.second;
-        nIndexes = pwallet->zwallet->RegenerateMintPoolEntry(get<0>(entry),get<1>(entry),get<2>(entry));
+        nIndexes = pwallet->zwallet->RegenerateMintPoolEntry(walletdb, get<0>(entry),get<1>(entry),get<2>(entry));
 
         if(nIndexes.first != oldHashPubcoin){
             walletdb.EraseMintPoolPair(oldHashPubcoin);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -84,7 +84,7 @@ bool EnsureWalletIsAvailable(CWallet * const pwallet, bool avoidException)
 
 void EnsureSigmaWalletIsAvailable()
 {
-    if (!zwalletMain) {
+    if (!pwalletMain->zwallet) {
         throw JSONRPCError(RPC_WALLET_ERROR, "sigma mint/spend is not allowed for legacy wallet");
     }
 }
@@ -2933,7 +2933,7 @@ UniValue regeneratemintpool(const JSONRPCRequest& request) {
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED,
                            "Error: Please enter the wallet passphrase with walletpassphrase first.");
 
-    if (!pwallet->IsHDSeedAvailable() || !zwalletMain) {
+    if (!pwallet->IsHDSeedAvailable() || !pwallet->zwallet) {
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED,
                            "Error: Can only regenerate mintpool on a HD-enabled wallet.");
     }
@@ -2955,10 +2955,10 @@ UniValue regeneratemintpool(const JSONRPCRequest& request) {
             mintPoolPair.first.GetHex(), get<0>(mintPoolPair.second).GetHex(), get<1>(mintPoolPair.second).GetHex(), get<2>(mintPoolPair.second));
 
         oldHashPubcoin = mintPoolPair.first;
-        bool hasSerial = zwalletMain->GetSerialForPubcoin(serialPubcoinPairs, oldHashPubcoin, oldHashSerial);
+        bool hasSerial = pwallet->zwallet->GetSerialForPubcoin(serialPubcoinPairs, oldHashPubcoin, oldHashSerial);
 
         MintPoolEntry entry = mintPoolPair.second;
-        nIndexes = zwalletMain->RegenerateMintPoolEntry(get<0>(entry),get<1>(entry),get<2>(entry));
+        nIndexes = pwallet->zwallet->RegenerateMintPoolEntry(get<0>(entry),get<1>(entry),get<2>(entry));
 
         if(nIndexes.first != oldHashPubcoin){
             walletdb.EraseMintPoolPair(oldHashPubcoin);
@@ -3751,7 +3751,7 @@ UniValue resetsigmamint(const JSONRPCRequest& request) {
 
     std::vector <CMintMeta> listMints;
     CWalletDB walletdb(pwallet->strWalletFile);
-    listMints = zwalletMain->GetTracker().ListMints(false, false);
+    listMints = pwallet->zwallet->GetTracker().ListMints(false, false);
 
     BOOST_FOREACH(CMintMeta &mint, listMints) {
         CHDMint dMint;
@@ -3760,7 +3760,7 @@ UniValue resetsigmamint(const JSONRPCRequest& request) {
         }
         dMint.SetUsed(false);
         dMint.SetHeight(-1);
-        zwalletMain->GetTracker().Add(dMint, true);
+        pwallet->zwallet->GetTracker().Add(dMint, true);
     }
 
     return NullUniValue;
@@ -3833,7 +3833,7 @@ UniValue listsigmamints(const JSONRPCRequest& request) {
 
     list <CSigmaEntry> listPubcoin;
     CWalletDB walletdb(pwallet->strWalletFile);
-    listPubcoin = zwalletMain->GetTracker().MintsAsSigmaEntries(false, false);
+    listPubcoin = pwallet->zwallet->GetTracker().MintsAsSigmaEntries(false, false);
     UniValue results(UniValue::VARR);
 
     BOOST_FOREACH(const CSigmaEntry &zerocoinItem, listPubcoin) {
@@ -3928,7 +3928,7 @@ UniValue listsigmapubcoins(const JSONRPCRequest& request) {
 
     list<CSigmaEntry> listPubcoin;
     CWalletDB walletdb(pwallet->strWalletFile);
-    listPubcoin = zwalletMain->GetTracker().MintsAsSigmaEntries(false, false);
+    listPubcoin = pwallet->zwallet->GetTracker().MintsAsSigmaEntries(false, false);
     UniValue results(UniValue::VARR);
     listPubcoin.sort(CompSigmaHeight);
 
@@ -4048,7 +4048,7 @@ UniValue setsigmamintstatus(const JSONRPCRequest& request) {
 
     std::vector <CMintMeta> listMints;
     CWalletDB walletdb(pwallet->strWalletFile);
-    listMints = zwalletMain->GetTracker().ListMints(false, false);
+    listMints = pwallet->zwallet->GetTracker().ListMints(false, false);
 
     UniValue results(UniValue::VARR);
 
@@ -4075,10 +4075,10 @@ UniValue setsigmamintstatus(const JSONRPCRequest& request) {
 
                 if(!mint.isDeterministic){
                     zerocoinItem.IsUsed = fStatus;
-                    zwalletMain->GetTracker().Add(zerocoinItem, true);
+                    pwallet->zwallet->GetTracker().Add(zerocoinItem, true);
                 }else{
                     dMint.SetUsed(fStatus);
-                    zwalletMain->GetTracker().Add(dMint, true);
+                    pwallet->zwallet->GetTracker().Add(dMint, true);
                 }
 
                 if (!fStatus) {

--- a/src/wallet/sigmaspendbuilder.cpp
+++ b/src/wallet/sigmaspendbuilder.cpp
@@ -168,13 +168,14 @@ CAmount SigmaSpendBuilder::GetChanges(std::vector<CTxOut>& outputs, CAmount amou
     auto params = sigma::Params::get_default();
 
     CHDMint hdMint;
+    CWalletDB walletdb(pwalletMain->strWalletFile);
     for (const auto& denomination : denomChanges) {
         CAmount denominationValue;
         sigma::DenominationToInteger(denomination, denominationValue);
 
         sigma::PrivateCoin newCoin(params, denomination, ZEROCOIN_TX_VERSION_3);
         hdMint.SetNull();
-        mintWallet.GenerateMint(denomination, newCoin, hdMint, boost::none, true);
+        mintWallet.GenerateMint(walletdb, denomination, newCoin, hdMint, boost::none, true);
         auto& pubCoin = newCoin.getPublicCoin();
 
         if (!pubCoin.validate()) {

--- a/src/wallet/sigmaspendbuilder.cpp
+++ b/src/wallet/sigmaspendbuilder.cpp
@@ -160,7 +160,7 @@ CAmount SigmaSpendBuilder::GetInputs(std::vector<std::unique_ptr<InputSigner>>& 
     return total;
 }
 
-CAmount SigmaSpendBuilder::GetChanges(std::vector<CTxOut>& outputs, CAmount amount)
+CAmount SigmaSpendBuilder::GetChanges(std::vector<CTxOut>& outputs, CAmount amount, CWalletDB& walletdb)
 {
     outputs.clear();
     changes.clear();
@@ -168,7 +168,6 @@ CAmount SigmaSpendBuilder::GetChanges(std::vector<CTxOut>& outputs, CAmount amou
     auto params = sigma::Params::get_default();
 
     CHDMint hdMint;
-    CWalletDB walletdb(pwalletMain->strWalletFile);
     for (const auto& denomination : denomChanges) {
         CAmount denominationValue;
         sigma::DenominationToInteger(denomination, denominationValue);

--- a/src/wallet/sigmaspendbuilder.h
+++ b/src/wallet/sigmaspendbuilder.h
@@ -21,7 +21,7 @@ public:
 protected:
     CAmount GetInputs(std::vector<std::unique_ptr<InputSigner>>& signers, CAmount required) override;
     // remint change
-    CAmount GetChanges(std::vector<CTxOut>& outputs, CAmount amount) override;
+    CAmount GetChanges(std::vector<CTxOut>& outputs, CAmount amount, CWalletDB& walletdb) override;
 
 private:
     CHDMintWallet& mintWallet;

--- a/src/wallet/test/sigma_tests.cpp
+++ b/src/wallet/test/sigma_tests.cpp
@@ -82,7 +82,7 @@ static void GenerateBlockWithCoins(const std::vector<std::pair<sigma::CoinDenomi
 
             // Generate and store secrets deterministically in the following function.
             dMint.SetNull();
-            pwalletMain->zwallet->GenerateMint(priv.getPublicCoin().getDenomination(), priv, dMint, boost::none, true);
+            pwalletMain->zwallet->GenerateMint(walletdb, priv.getPublicCoin().getDenomination(), priv, dMint, boost::none, true);
 
             auto& pub = priv.getPublicCoin();
 

--- a/src/wallet/test/sigma_tests.cpp
+++ b/src/wallet/test/sigma_tests.cpp
@@ -82,14 +82,14 @@ static void GenerateBlockWithCoins(const std::vector<std::pair<sigma::CoinDenomi
 
             // Generate and store secrets deterministically in the following function.
             dMint.SetNull();
-            zwalletMain->GenerateMint(priv.getPublicCoin().getDenomination(), priv, dMint, boost::none, true);
+            pwalletMain->zwallet->GenerateMint(priv.getPublicCoin().getDenomination(), priv, dMint, boost::none, true);
 
             auto& pub = priv.getPublicCoin();
 
             block->second.sigmaMintedPubCoins[std::make_pair(coin.first, 1)].push_back(pub);
 
             if (addToWallet) {
-                zwalletMain->GetTracker().Add(dMint, true);
+                pwalletMain->zwallet->GetTracker().Add(dMint, true);
             }
         }
     }

--- a/src/wallet/test/sigma_tests.cpp
+++ b/src/wallet/test/sigma_tests.cpp
@@ -75,6 +75,7 @@ static void GenerateBlockWithCoins(const std::vector<std::pair<sigma::CoinDenomi
     block->second.nHeight = block->second.pprev->nHeight + 1;
 
     // generate coins
+    CWalletDB walletdb(pwalletMain->strWalletFile);
     CHDMint dMint;
     for (auto& coin : coins) {
         for (int i = 0; i < coin.second; i++) {
@@ -89,7 +90,7 @@ static void GenerateBlockWithCoins(const std::vector<std::pair<sigma::CoinDenomi
             block->second.sigmaMintedPubCoins[std::make_pair(coin.first, 1)].push_back(pub);
 
             if (addToWallet) {
-                pwalletMain->zwallet->GetTracker().Add(dMint, true);
+                pwalletMain->zwallet->GetTracker().Add(walletdb, dMint, true);
             }
         }
     }

--- a/src/wallet/txbuilder.cpp
+++ b/src/wallet/txbuilder.cpp
@@ -104,13 +104,13 @@ CWalletTx TxBuilder::Build(const std::vector<CRecipient>& recipients, CAmount& f
 
     // Start with no fee and loop until there is enough fee;
     uint32_t nCountNextUse;
-    if (zwalletMain) {
-        nCountNextUse = zwalletMain->GetCount();
+    if (pwalletMain->zwallet) {
+        nCountNextUse = pwalletMain->zwallet->GetCount();
     }
     for (fee = payTxFee.GetFeePerK();;) {
         // In case of not enough fee, reset mint seed counter
-        if (zwalletMain) {
-            zwalletMain->SetCount(nCountNextUse);
+        if (pwalletMain->zwallet) {
+            pwalletMain->zwallet->SetCount(nCountNextUse);
         }
         CAmount required = spend;
 

--- a/src/wallet/txbuilder.cpp
+++ b/src/wallet/txbuilder.cpp
@@ -39,7 +39,7 @@ TxBuilder::~TxBuilder()
 {
 }
 
-CWalletTx TxBuilder::Build(const std::vector<CRecipient>& recipients, CAmount& fee,  bool& fChangeAddedToFee)
+CWalletTx TxBuilder::Build(const std::vector<CRecipient>& recipients, CAmount& fee,  bool& fChangeAddedToFee, CWalletDB& walletdb)
 {
     if (recipients.empty()) {
         throw std::invalid_argument(_("No recipients"));
@@ -172,7 +172,7 @@ CWalletTx TxBuilder::Build(const std::vector<CRecipient>& recipients, CAmount& f
         if (change > 0) {
             // get changes outputs
             std::vector<CTxOut> changes;
-            CAmount addToFee = GetChanges(changes, change);
+            CAmount addToFee = GetChanges(changes, change, walletdb);
             if(addToFee > 0)
                 fChangeAddedToFee = true;
             fee += addToFee;

--- a/src/wallet/txbuilder.h
+++ b/src/wallet/txbuilder.h
@@ -37,11 +37,11 @@ public:
     explicit TxBuilder(CWallet& wallet) noexcept;
     virtual ~TxBuilder();
 
-    CWalletTx Build(const std::vector<CRecipient>& recipients, CAmount& fee,  bool& fChangeAddedToFee);
+    CWalletTx Build(const std::vector<CRecipient>& recipients, CAmount& fee,  bool& fChangeAddedToFee, CWalletDB& walletdb);
 
 protected:
     virtual CAmount GetInputs(std::vector<std::unique_ptr<InputSigner>>& signers, CAmount required) = 0;
-    virtual CAmount GetChanges(std::vector<CTxOut>& outputs, CAmount amount) = 0;
+    virtual CAmount GetChanges(std::vector<CTxOut>& outputs, CAmount amount, CWalletDB& walletdb) = 0;
     virtual CAmount AdjustFee(CAmount needed, unsigned txSize);
 };
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -102,7 +102,7 @@ struct CompareByAmount
 
 static void EnsureMintWalletAvailable()
 {
-    if (!pwalletMain->zwallet) {
+    if (!pwalletMain || !pwalletMain->zwallet) {
         throw std::logic_error("Sigma feature requires HD wallet");
     }
 }
@@ -175,7 +175,7 @@ CPubKey CWallet::GetKeyFromKeypath(uint32_t nChange, uint32_t nChild) {
     return pubkey;
 }
 
-CPubKey CWallet::GenerateNewKey(uint32_t nChange, bool nWriteChain)
+CPubKey CWallet::GenerateNewKey(uint32_t nChange, bool fWriteChain)
 {
     AssertLockHeld(cs_wallet); // mapKeyMetadata
     bool fCompressed = CanSupportFeature(FEATURE_COMPRPUBKEY); // default to compressed public keys if we want 0.6.0 wallets
@@ -242,7 +242,7 @@ CPubKey CWallet::GenerateNewKey(uint32_t nChange, bool nWriteChain)
         secret = childKey.key;
 
         // update the chain model in the database
-        if(nWriteChain){
+        if(fWriteChain){
             if (!CWalletDB(strWalletFile).WriteHDChain(hdChain))
                 throw std::runtime_error(std::string(__func__) + ": Writing HD chain model failed");
         }
@@ -5646,8 +5646,8 @@ CWalletTx CWallet::CreateSigmaSpendTransaction(
 
     // create transaction
     SigmaSpendBuilder builder(*this, *zwallet, coinControl);
-
-    CWalletTx tx = builder.Build(recipients, fee, fChangeAddedToFee);
+    CWalletDB walletdb(strWalletFile);
+    CWalletTx tx = builder.Build(recipients, fee, fChangeAddedToFee, walletdb);
     selected = builder.selected;
     changes = builder.changes;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -8093,7 +8093,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
 
     LogPrintf(" wallet      %15dms\n", GetTimeMillis() - nStart);
     if (pwalletMain->IsHDSeedAvailable()) {
-        walletInstance->zwallet = new CHDMintWallet(pwalletMain->strWalletFile);
+        walletInstance->zwallet = std::make_unique<CHDMintWallet>(pwalletMain->strWalletFile);
     }
 
     RegisterValidationInterface(walletInstance);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -54,7 +54,7 @@
 using namespace std;
 
 CWallet* pwalletMain = NULL;
-CHDMintWallet* zwalletMain = NULL;
+
 /** Transaction fee set by the user */
 CFeeRate payTxFee(DEFAULT_TRANSACTION_FEE);
 unsigned int nTxConfirmTarget = DEFAULT_TX_CONFIRM_TARGET;
@@ -102,7 +102,7 @@ struct CompareByAmount
 
 static void EnsureMintWalletAvailable()
 {
-    if (!zwalletMain) {
+    if (!pwalletMain->zwallet) {
         throw std::logic_error("Sigma feature requires HD wallet");
     }
 }
@@ -706,11 +706,11 @@ bool CWallet::IsSpent(const uint256 &hash, unsigned int n) const
             }
 
             return data.IsUsed;
-        } else if (zwalletMain && script.IsSigmaMint()) {
+        } else if (pwalletMain->zwallet && script.IsSigmaMint()) {
             auto pub = sigma::ParseSigmaMintScript(script);
             uint256 hashPubcoin = primitives::GetPubCoinValueHash(pub);
             CMintMeta meta;
-            if(!zwalletMain->GetTracker().GetMetaFromPubcoin(hashPubcoin, meta)){
+            if(!zwallet->GetTracker().GetMetaFromPubcoin(hashPubcoin, meta)){
                 return false;
             }
             return meta.isUsed;
@@ -1362,9 +1362,9 @@ bool CWallet::AbandonTransaction(const uint256& hashTx)
             // mark corresponding mint as unspent
             uint256 hashSerial = primitives::GetSerialHash(serial);
             CMintMeta meta;
-            if(zwalletMain->GetTracker().GetMetaFromSerial(hashSerial, meta)){
+            if(zwallet->GetTracker().GetMetaFromSerial(hashSerial, meta)){
                 meta.isUsed = false;
-                zwalletMain->GetTracker().UpdateState(meta);
+                zwallet->GetTracker().UpdateState(meta);
 
                 // erase zerocoin spend entry
                 CSigmaSpendEntry spendEntry;
@@ -2494,7 +2494,7 @@ std::vector<CRecipient> CWallet::CreateSigmaMintRecipients(
 
             // Generate and store secrets deterministically in the following function.
             CHDMint dMint;
-            zwalletMain->GenerateMint(coin.getPublicCoin().getDenomination(), coin, dMint);
+            pwalletMain->zwallet->GenerateMint(coin.getPublicCoin().getDenomination(), coin, dMint);
 
 
             // Get a copy of the 'public' portion of the coin. You should
@@ -2599,7 +2599,7 @@ std::list<CSigmaEntry> CWallet::GetAvailableCoins(const CCoinControl *coinContro
     LOCK2(cs_main, cs_wallet);
     CWalletDB walletdb(strWalletFile);
     std::list<CSigmaEntry> coins;
-    std::vector<CMintMeta> vecMints = zwalletMain->GetTracker().ListMints(true, true, false);
+    std::vector<CMintMeta> vecMints = zwallet->GetTracker().ListMints(true, true, false);
     list<CMintMeta> listMints(vecMints.begin(), vecMints.end());
     for (const CMintMeta& mint : listMints) {
         CSigmaEntry entry;
@@ -3093,7 +3093,7 @@ void CWallet::ListAvailableSigmaMintCoins(vector<COutput> &vCoins, bool fOnlyCon
     LOCK2(cs_main, cs_wallet);
     list<CSigmaEntry> listOwnCoins;
     CWalletDB walletdb(pwalletMain->strWalletFile);
-    listOwnCoins = zwalletMain->GetTracker().MintsAsSigmaEntries(true, false);
+    listOwnCoins = zwallet->GetTracker().MintsAsSigmaEntries(true, false);
     LogPrintf("listOwnCoins.size()=%s\n", listOwnCoins.size());
     for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
         const CWalletTx *pcoin = &(*it).second;
@@ -3973,7 +3973,7 @@ bool CWallet::CreateSigmaMintModel(
 
             // Generate and store secrets deterministically in the following function.
             dMint.SetNull();
-            zwalletMain->GenerateMint(denomination, newCoin, dMint);
+            zwallet->GenerateMint(denomination, newCoin, dMint);
 
             // Get a copy of the 'public' portion of the coin. You should
             // embed this into a Zerocoin 'MINT' transaction along with a series
@@ -4157,7 +4157,7 @@ bool CWallet::CreateSigmaMintModel(string &stringError, const string& denomAmoun
 
     CHDMint dMint;
 
-    uint32_t nCountNextUse = zwalletMain->GetCount();
+    uint32_t nCountNextUse = zwallet->GetCount();
 
     // Set up the Zerocoin Params object
     sigma::Params *sigmaParams = sigma::Params::get_default();
@@ -4170,7 +4170,7 @@ bool CWallet::CreateSigmaMintModel(string &stringError, const string& denomAmoun
 
     // Generate and store secrets deterministically in the following function.
     dMint.SetNull();
-    zwalletMain->GenerateMint(denomination, newCoin, dMint);
+    zwallet->GenerateMint(denomination, newCoin, dMint);
 
     // Get a copy of the 'public' portion of the coin. You should
     // embed this into a Zerocoin 'MINT' transaction along with a series
@@ -4203,7 +4203,7 @@ bool CWallet::CreateSigmaMintModel(string &stringError, const string& denomAmoun
         CWalletDB walletdb(pwalletMain->strWalletFile);
 
         dMint.SetTxHash(wtx.GetHash());
-        zwalletMain->GetTracker().Add(dMint, true);
+        zwallet->GetTracker().Add(dMint, true);
 
         LogPrintf("CreateZerocoinMintModel() -> NotifyZerocoinChanged\n");
         LogPrintf("pubcoin=%s, isUsed=%s\n", newCoin.getPublicCoin().getValue().GetHex(), dMint.IsUsed());
@@ -4216,7 +4216,7 @@ bool CWallet::CreateSigmaMintModel(string &stringError, const string& denomAmoun
         return true;
     } else {
         // reset coin count
-        zwalletMain->SetCount(nCountNextUse);
+        zwallet->SetCount(nCountNextUse);
         return false;
     }
 }
@@ -4441,14 +4441,14 @@ bool CWallet::CreateZerocoinToSigmaRemintModel(string &stringError, int version,
 
             // Generate and store secrets deterministically in the following function.
             CHDMint hdMint;
-            zwalletMain->GenerateMint(newCoin.getPublicCoin().getDenomination(), newCoin, hdMint);
+            zwallet->GenerateMint(newCoin.getPublicCoin().getDenomination(), newCoin, hdMint);
 
             sigma::PublicCoin pubCoin = newCoin.getPublicCoin();
 
             // Validate
             if (!pubCoin.validate()) {
                 stringError = "Unable to mint a sigma coin";
-                zwalletMain->ResetCount();
+                zwallet->ResetCount();
                 return false;
             }
 
@@ -4460,7 +4460,7 @@ bool CWallet::CreateZerocoinToSigmaRemintModel(string &stringError, int version,
             int64_t intDenomination;
             if (!sigma::DenominationToInteger(denomMap.sigmaDenomination, intDenomination)) {
                 stringError = "Unknown sigma denomination";
-                zwalletMain->ResetCount();
+                zwallet->ResetCount();
                 return false;
             }
 
@@ -4523,7 +4523,7 @@ bool CWallet::CreateZerocoinToSigmaRemintModel(string &stringError, int version,
     //update mints with full transaction hash and then database them
     for (CHDMint hdMint : vHDMints) {
         hdMint.SetTxHash(wtxNew.GetHash());
-        zwalletMain->GetTracker().Add(hdMint, true);
+        zwallet->GetTracker().Add(hdMint, true);
         NotifyZerocoinChanged(this,
             hdMint.GetPubcoinValue().GetHex(),
             "New (" + std::to_string(hdMint.GetDenominationValue()) + " mint)",
@@ -4531,7 +4531,7 @@ bool CWallet::CreateZerocoinToSigmaRemintModel(string &stringError, int version,
     }
 
     // Update nCountNextUse in HDMint wallet database
-    zwalletMain->UpdateCountDB();
+    zwallet->UpdateCountDB();
 
     if (wtx)
         *wtx = wtxNew;
@@ -5437,7 +5437,7 @@ bool CWallet::CreateSigmaSpendTransaction(
 
             // Get Mint metadata objects
             vector<CMintMeta> setMints;
-            setMints = zwalletMain->GetTracker().ListMints(!forceUsed, !forceUsed, !forceUsed);
+            setMints = zwallet->GetTracker().ListMints(!forceUsed, !forceUsed, !forceUsed);
 
             // Cycle through metadata, looking for suitable coin
             list<CMintMeta> listMints(setMints.begin(), setMints.end());
@@ -5550,14 +5550,14 @@ bool CWallet::CreateSigmaSpendTransaction(
                     // THIS SELECTED COIN HAS BEEN USED, SO UPDATE ITS STATUS
                     strFailReason = _("Trying to spend an already spent serial #, try again.");
                     uint256 hashSerial = primitives::GetSerialHash(spend.getCoinSerialNumber());
-                    if (!zwalletMain->GetTracker().HasSerialHash(hashSerial)){
+                    if (!zwallet->GetTracker().HasSerialHash(hashSerial)){
                         strFailReason = "Tracker does not have serialhash " + hashSerial.GetHex();
                         return false;
                     }
                     CMintMeta meta;
-                    zwalletMain->GetTracker().GetMetaFromSerial(hashSerial, meta);
+                    zwallet->GetTracker().GetMetaFromSerial(hashSerial, meta);
                     meta.isUsed = true;
-                    zwalletMain->GetTracker().UpdateState(meta);
+                    zwallet->GetTracker().UpdateState(meta);
                     LogPrintf("CreateZerocoinSpendTransaction() -> NotifyZerocoinChanged\n");
                     LogPrintf("pubcoin=%s, isUsed=Used\n", coinToUse.value.GetHex());
                     pwalletMain->NotifyZerocoinChanged(
@@ -5643,7 +5643,7 @@ CWalletTx CWallet::CreateSigmaSpendTransaction(
     }
 
     // create transaction
-    SigmaSpendBuilder builder(*this, *zwalletMain, coinControl);
+    SigmaSpendBuilder builder(*this, *zwallet, coinControl);
 
     CWalletTx tx = builder.Build(recipients, fee, fChangeAddedToFee);
     selected = builder.selected;
@@ -6038,7 +6038,7 @@ bool CWallet::CreateMultipleSigmaSpendTransaction(
 
             // Get Mint metadata objects
             vector<CMintMeta> setMints;
-            setMints = zwalletMain->GetTracker().ListMints(!forceUsed, !forceUsed, !forceUsed);
+            setMints = zwallet->GetTracker().ListMints(!forceUsed, !forceUsed, !forceUsed);
             vector<CMintMeta> listMints(setMints.begin(), setMints.end());
 
             // Total value of all inputs. Iteritively created in the following loop
@@ -6254,14 +6254,14 @@ bool CWallet::CreateMultipleSigmaSpendTransaction(
                         // THIS SELECTED COIN HAS BEEN USED, SO UPDATE ITS STATUS
                         strFailReason = _("Trying to spend an already spent serial #, try again.");
                         uint256 hashSerial = primitives::GetSerialHash(spend.getCoinSerialNumber());
-                        if (!zwalletMain->GetTracker().HasSerialHash(hashSerial)){
+                        if (!zwallet->GetTracker().HasSerialHash(hashSerial)){
                             strFailReason = "Tracker does not have serialhash " + hashSerial.GetHex();
                             return false;
                         }
                         CMintMeta meta;
-                        zwalletMain->GetTracker().GetMetaFromSerial(hashSerial, meta);
+                        zwallet->GetTracker().GetMetaFromSerial(hashSerial, meta);
                         meta.isUsed = true;
-                        zwalletMain->GetTracker().UpdateState(meta);
+                        zwallet->GetTracker().UpdateState(meta);
                         LogPrintf("CreateZerocoinSpendTransaction() -> NotifyZerocoinChanged\n");
                         LogPrintf("pubcoin=%s, isUsed=Used\n", coinToUse.value.GetHex());
                         pwalletMain->NotifyZerocoinChanged(
@@ -6581,7 +6581,7 @@ string CWallet::MintAndStoreSigma(const vector<CRecipient>& vecSend,
     CWalletDB walletdb(pwalletMain->strWalletFile);
     for (CHDMint dMint : vDMints) {
         dMint.SetTxHash(wtxNew.GetHash());
-        zwalletMain->GetTracker().Add(dMint, true);
+        zwallet->GetTracker().Add(dMint, true);
         NotifyZerocoinChanged(this,
              dMint.GetPubcoinValue().GetHex(),
             "New (" + std::to_string(dMint.GetDenominationValue()) + " mint)",
@@ -6589,7 +6589,7 @@ string CWallet::MintAndStoreSigma(const vector<CRecipient>& vecSend,
     }
 
     // Update nCountNextUse in HDMint wallet database
-    zwalletMain->UpdateCountDB();
+    zwallet->UpdateCountDB();
 
     return "";
 }
@@ -6768,7 +6768,7 @@ string CWallet::SpendSigma(
 
         //reset mint
         uint256 hashPubcoin = primitives::GetPubCoinValueHash(zcSelectedValue);
-        zwalletMain->GetTracker().SetPubcoinNotUsed(hashPubcoin);
+        zwallet->GetTracker().SetPubcoinNotUsed(hashPubcoin);
         pwalletMain->NotifyZerocoinChanged(pwalletMain, zcSelectedValue.GetHex(), "New", CT_UPDATED);
 
         CSigmaSpendEntry entry;
@@ -6786,10 +6786,10 @@ string CWallet::SpendSigma(
     uint256 txidSpend = wtxNew.GetHash();
 
     uint256 hashPubcoin = primitives::GetPubCoinValueHash(zcSelectedValue);
-    zwalletMain->GetTracker().SetPubcoinUsed(hashPubcoin, txidSpend);
+    zwallet->GetTracker().SetPubcoinUsed(hashPubcoin, txidSpend);
 
     CMintMeta metaCheck;
-    zwalletMain->GetTracker().GetMetaFromPubcoin(hashPubcoin, metaCheck);
+    zwallet->GetTracker().GetMetaFromPubcoin(hashPubcoin, metaCheck);
     if (!metaCheck.isUsed) {
         strError = "Error, mint with pubcoin hash " + hashPubcoin.GetHex() + " did not get marked as used";
         LogPrintf("SpendZerocoin() : %s\n", strError.c_str());
@@ -6909,7 +6909,7 @@ string CWallet::SpendMultipleSigma(
             int index = it - coinSerials.begin();
             GroupElement zcSelectedValue = zcSelectedValues[index];
             uint256 hashPubcoin = primitives::GetPubCoinValueHash(zcSelectedValue);
-            zwalletMain->GetTracker().SetPubcoinNotUsed(hashPubcoin);
+            zwallet->GetTracker().SetPubcoinNotUsed(hashPubcoin);
             pwalletMain->NotifyZerocoinChanged(pwalletMain, zcSelectedValue.GetHex(), "New", CT_UPDATED);
 
             CSigmaSpendEntry entry;
@@ -6931,9 +6931,9 @@ string CWallet::SpendMultipleSigma(
 
     BOOST_FOREACH(GroupElement zcSelectedValue, zcSelectedValues){
         uint256 hashPubcoin = primitives::GetPubCoinValueHash(zcSelectedValue);
-        zwalletMain->GetTracker().SetPubcoinUsed(hashPubcoin, txidSpend);
+        zwallet->GetTracker().SetPubcoinUsed(hashPubcoin, txidSpend);
         CMintMeta metaCheck;
-        zwalletMain->GetTracker().GetMetaFromPubcoin(hashPubcoin, metaCheck);
+        zwallet->GetTracker().GetMetaFromPubcoin(hashPubcoin, metaCheck);
         if (!metaCheck.isUsed) {
             strError = "Error, mint with pubcoin hash " + hashPubcoin.GetHex() + " did not get marked as used";
             LogPrintf("SpendZerocoin() : %s\n", strError.c_str());
@@ -7012,16 +7012,16 @@ bool CWallet::CommitSigmaTransaction(CWalletTx& wtxNew, std::vector<CSigmaEntry>
 
         //Set spent mint as used in memory
         uint256 hashPubcoin = primitives::GetPubCoinValueHash(coin.value);
-        zwalletMain->GetTracker().SetPubcoinUsed(hashPubcoin, wtxNew.GetHash());
+        zwallet->GetTracker().SetPubcoinUsed(hashPubcoin, wtxNew.GetHash());
         CMintMeta metaCheck;
-        zwalletMain->GetTracker().GetMetaFromPubcoin(hashPubcoin, metaCheck);
+        zwallet->GetTracker().GetMetaFromPubcoin(hashPubcoin, metaCheck);
         if (!metaCheck.isUsed) {
             string strError = "Error, mint with pubcoin hash " + hashPubcoin.GetHex() + " did not get marked as used";
             LogPrintf("SpendZerocoin() : %s\n", strError.c_str());
         }
 
         //Set spent mint as used in DB
-        zwalletMain->GetTracker().UpdateState(metaCheck);
+        zwallet->GetTracker().UpdateState(metaCheck);
 
         // update CSigmaEntry
         coin.IsUsed = true;
@@ -7038,7 +7038,7 @@ bool CWallet::CommitSigmaTransaction(CWalletTx& wtxNew, std::vector<CSigmaEntry>
 
     for (auto& change : changes) {
         change.SetTxHash(wtxNew.GetHash());
-        zwalletMain->GetTracker().Add(change, true);
+        zwallet->GetTracker().Add(change, true);
 
         // raise event
         NotifyZerocoinChanged(this,
@@ -7048,7 +7048,7 @@ bool CWallet::CommitSigmaTransaction(CWalletTx& wtxNew, std::vector<CSigmaEntry>
     }
 
     // Update nCountNextUse in HDMint wallet database
-    zwalletMain->UpdateCountDB();
+    zwallet->UpdateCountDB();
 
     return true;
 }
@@ -7062,7 +7062,7 @@ bool CWallet::GetMint(const uint256& hashSerial, CSigmaEntry& zerocoin) const
     }
 
     CMintMeta meta;
-    if(!zwalletMain->GetTracker().GetMetaFromSerial(hashSerial, meta))
+    if(!zwallet->GetTracker().GetMetaFromSerial(hashSerial, meta))
         return error("%s: serialhash %s is not in tracker", __func__, hashSerial.GetHex());
 
     CWalletDB walletdb(strWalletFile);
@@ -7070,7 +7070,7 @@ bool CWallet::GetMint(const uint256& hashSerial, CSigmaEntry& zerocoin) const
         CHDMint dMint;
         if (!walletdb.ReadHDMint(meta.GetPubCoinValueHash(), dMint))
             return error("%s: failed to read deterministic mint", __func__);
-        if (!zwalletMain->RegenerateMint(dMint, zerocoin))
+        if (!zwallet->RegenerateMint(dMint, zerocoin))
             return error("%s: failed to generate mint", __func__);
 
          return true;
@@ -8093,7 +8093,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
 
     LogPrintf(" wallet      %15dms\n", GetTimeMillis() - nStart);
     if (pwalletMain->IsHDSeedAvailable()) {
-        zwalletMain = new CHDMintWallet(pwalletMain->strWalletFile);
+        walletInstance->zwallet = new CHDMintWallet(pwalletMain->strWalletFile);
     }
 
     RegisterValidationInterface(walletInstance);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -750,7 +750,7 @@ public:
     MasterKeyMap mapMasterKeys;
     unsigned int nMasterKeyMaxID;
 
-    CHDMintWallet* zwallet;
+    std::unique_ptr<CHDMintWallet> zwallet;
 
     CWallet()
     {
@@ -767,8 +767,6 @@ public:
     {
         delete pwalletdbEncryption;
         pwalletdbEncryption = NULL;
-        delete zwallet;
-        zwallet = NULL;
     }
 
     void SetNull()

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -767,6 +767,8 @@ public:
     {
         delete pwalletdbEncryption;
         pwalletdbEncryption = NULL;
+        delete zwallet;
+        zwallet = NULL;
     }
 
     void SetNull()

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -846,7 +846,7 @@ public:
      * keystore implementation
      * Generate a new key
      */
-    CPubKey GenerateNewKey(uint32_t nChange=0);
+    CPubKey GenerateNewKey(uint32_t nChange=0, bool nWriteChain=true);
     void DeriveNewChildKey(CKeyMetadata& metadata, CKey& secret);
     //! Adds a key to the store, and saves it to disk.
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -44,7 +44,6 @@
 #include <boost/thread.hpp>
 
 extern CWallet* pwalletMain;
-extern CHDMintWallet* zwalletMain;
 
 /**
  * Settings
@@ -751,6 +750,8 @@ public:
     MasterKeyMap mapMasterKeys;
     unsigned int nMasterKeyMaxID;
 
+    CHDMintWallet* zwallet;
+
     CWallet()
     {
         SetNull();
@@ -784,6 +785,7 @@ public:
         fAnonymizableTallyCachedNonDenom = false;
         vecAnonymizableTallyCached.clear();
         vecAnonymizableTallyCachedNonDenom.clear();
+        zwallet = NULL;
     }
 
     std::map<uint256, CWalletTx> mapWallet;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -846,7 +846,7 @@ public:
      * keystore implementation
      * Generate a new key
      */
-    CPubKey GenerateNewKey(uint32_t nChange=0, bool nWriteChain=true);
+    CPubKey GenerateNewKey(uint32_t nChange=0, bool fWriteChain=true);
     void DeriveNewChildKey(CKeyMetadata& metadata, CKey& secret);
     //! Adds a key to the store, and saves it to disk.
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override;


### PR DESCRIPTION
- make CHDMintWallet a member of CWallet (to better handle multiple wallet architecture in core 14)

- Mac test optimisations: 
     - make walletDB object a part of `CHDMintWallet`, pass as reference where possible
     - minimuse file I/O

- some HDMint code cleanup