### PR TITLE
Remove unnecessary code on sigma mint addition to the mempool

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1334,18 +1334,9 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
     if(markZcoinSpendTransactionSerial)
         sigmaState->AddMintsToMempool(zcMintPubcoinsV3);
 #ifdef ENABLE_WALLET
-    if(tx.IsSigmaMint()){
-        BOOST_FOREACH(const CTxOut &txout, tx.vout)
-        {
-            if(txout.scriptPubKey.IsSigmaMint()){
-                GroupElement pubCoinValue = sigma::ParseSigmaMintScript(txout.scriptPubKey);
-                zcMintPubcoinsV3.push_back(pubCoinValue);
-            }
-        }
-        if (zwalletMain) {
-            LogPrintf("Updating mint state from Mempool..");
-            zwalletMain->GetTracker().UpdateMintStateFromMempool(zcMintPubcoinsV3);
-        }
+    if(tx.IsSigmaMint() && zwalletMain) {
+        LogPrintf("Updating mint state from Mempool..");
+        zwalletMain->GetTracker().UpdateMintStateFromMempool(zcMintPubcoinsV3);
     }
 #endif
     GetMainSignals().SyncTransaction(tx, NULL, CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK);


### PR DESCRIPTION
## PR intention
Remove unnecessary code

## Code changes brief
During AcceptToMemoryPool() there was extra code causing `zcMintPubcoinsV3` to contain every element twice. This PR solves this issue without changing functionality