### PR TITLE
Update elysium spend v1 activation block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ src/zcoin
 src/zcoind
 src/zcoin-cli
 src/zcoin-tx
+src/test/test_bitcoin_fuzzy
 src/test/test_zcoin
 src/test/test_zcoin_fuzzy
 src/qt/test/test_zcoin-qt
@@ -117,7 +118,8 @@ qa/cache/*
 
 !src/leveldb*/Makefile
 
-/doc/doxygen/
+doc/doxygen/
+doc/man/Makefile
 
 libzcoinconsensus.pc
 contrib/devtools/split-debug.sh

--- a/src/elysium/rules.cpp
+++ b/src/elysium/rules.cpp
@@ -132,7 +132,7 @@ CMainConsensusParams::CMainConsensusParams()
 
     // Sigma releated
     SIGMA_FEATURE_BLOCK = 212000; // 4 Nov 2019
-    SIGMA_SPENDV1_FEATURE_BLOCK = 264165; // 4 May 2020
+    SIGMA_SPENDV1_FEATURE_BLOCK = 281532; // 1 July 2020
 
     // Property creation fee
     PROPERTY_CREATION_FEE_BLOCK = 212000;


### PR DESCRIPTION
## PR intention
Update block to activate Elysium spend v1

## Code changes brief
- Update gitignore
- Update to block 281532 (08:02 am,  1 July 2020)
