### PR TITLE
Fixes for Znode warning

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1099,6 +1099,10 @@ void BitcoinGUI::setAdditionalDataSyncProgress(double nSyncProgress)
         progressBarLabel->setVisible(false);
         progressBar->setVisible(false);
         labelBlocksIcon->setPixmap(platformStyle->SingleColorIcon(":/icons/synced").pixmap(STATUSBAR_ICONSIZE, STATUSBAR_ICONSIZE));
+        //also check for Znode warning here
+        if(NotifyZnodeWarning::shouldShow()){
+            NotifyZnodeWarning::notify();
+        }
     } else {
 
         labelBlocksIcon->setPixmap(platformStyle->SingleColorIcon(QString(

--- a/src/qt/notifyznodewarning.cpp
+++ b/src/qt/notifyznodewarning.cpp
@@ -31,7 +31,7 @@ void NotifyZnodeWarning::notify()
         (int)hoursToEnforcement);
 
     SetMiscWarning(strWarning);
-    AlertNotify(strWarning);
+    uiInterface.NotifyAlertChanged();
 }
 
 bool NotifyZnodeWarning::shouldShow()

--- a/src/qt/notifyznodewarning.cpp
+++ b/src/qt/notifyznodewarning.cpp
@@ -2,9 +2,12 @@
 
 #include "evo/deterministicmns.h"
 #include "znode.h"
+#include "znodesync-interface.h"
 #include "chain.h"
 #include "znodeconfig.h"
 #include "znodeman.h"
+#include "warnings.h"
+#include "validation.h"
 
 
 #ifdef ENABLE_WALLET
@@ -12,14 +15,10 @@
 #include "wallet/wallet.h"
 #endif
 
-#include <QMessageBox>
-#include <QAbstractButton>
-
 bool NotifyZnodeWarning::nConsidered = false;
 
 void NotifyZnodeWarning::notify()
 {
-    QMessageBox msg;
     const Consensus::Params& params = ::Params().GetConsensus();
     float numBlocksToEnforcement = params.DIP0003EnforcementHeight - chainActive.Tip()->nHeight;
     float minutesToEnforcement = numBlocksToEnforcement * (params.nPowTargetSpacingMTP / 60);
@@ -27,22 +26,22 @@ void NotifyZnodeWarning::notify()
     float daysToEnforcement = floor(daysDecimal);
     float hoursToEnforcement = floor((daysDecimal > 0 ? (daysDecimal - daysToEnforcement) : 0) * 24);
 
-    QString messageWarning = QString("WARNING: Legacy znodes detected. You should migrate to the new Znode layout before it becomes enforced (approximately %1 days and %2 hours). For details on how to migrate, go to https://zcoin.io/znode-migration")
-    .arg(QString::number((int)daysToEnforcement, 10))
-    .arg(QString::number((int)hoursToEnforcement, 10));
-    msg.setText(messageWarning);
-    msg.setIcon(QMessageBox::Warning);
-    msg.exec();
-    nConsidered = true;
+    std::string strWarning = strprintf(_("WARNING: Legacy znodes detected. You should migrate to the new Znode layout before it becomes enforced (approximately %i days and %i hours). For details on how to migrate, go to https://zcoin.io/znode-migration"),
+        (int)daysToEnforcement,
+        (int)hoursToEnforcement);
+
+    SetMiscWarning(strWarning);
+    AlertNotify(strWarning);
 }
 
 bool NotifyZnodeWarning::shouldShow()
 {
 #ifdef ENABLE_WALLET
-    if(nConsidered || // already fully considered warning
-       znodeConfig.getCount() == 0 || // no legacy znodes detected
-       !CZnode::IsLegacyWindow(chainActive.Tip()->nHeight) // outside of legacy window
-       || !pwalletMain) // wallet not yet loaded
+    if(nConsidered ||                                         // already fully considered warning
+       znodeConfig.getCount() == 0 ||                         // no legacy znodes detected
+       !CZnode::IsLegacyWindow(chainActive.Tip()->nHeight) || // outside of legacy window
+       !pwalletMain ||                                        // wallet not yet loaded
+       !znodeSyncInterface.IsSynced())                        // znode state not yet synced
         return false;
 
     // get Znode entries.
@@ -75,8 +74,10 @@ bool NotifyZnodeWarning::shouldShow()
         }
 
         // if collateral not found, show warning.
-        if(!foundOutpoint)
+        if(!foundOutpoint){
+            nConsidered = true;
             return true;
+        }
     }
 
     // if we get to here, the warning will never be shown, and so is fully considered (All znodes ported or expired)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -738,6 +738,7 @@ bool CWallet::IsSpent(const uint256 &hash, unsigned int n) const
 void CWallet::AddToSpends(const COutPoint& outpoint, const uint256& wtxid)
 {
     mapTxSpends.insert(make_pair(outpoint, wtxid));
+    setWalletUTXO.erase(outpoint);
 
     pair<TxSpends::iterator, TxSpends::iterator> range;
     range = mapTxSpends.equal_range(outpoint);
@@ -7153,6 +7154,17 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
             // Note: can't top-up keypool here, because wallet is locked.
             // User will be prompted to unlock wallet the next operation
             // that requires a new key.
+        }
+    }
+
+    {
+        LOCK2(cs_main, cs_wallet);
+        for (auto& pair : mapWallet) {
+            for(unsigned int i = 0; i < pair.second.tx->vout.size(); ++i) {
+                if (IsMine(pair.second.tx->vout[i]) && !IsSpent(pair.first, i)) {
+                    setWalletUTXO.insert(COutPoint(pair.first, i));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Separating this from https://github.com/zcoinofficial/zcoin/pull/846 for easier review

GUI changes to fix Znode warning. Now shows warning at the overview screen rather than as a popup, given that the warning logic is not executed until znode sync is complete.
