### PR TITLE
Fix elysium reindexing tests

### DIFF
--- a/qa/rpc-tests/elysium_sigma_reindex.py
+++ b/qa/rpc-tests/elysium_sigma_reindex.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from test_framework.test_framework import ElysiumTestFramework
 from test_framework.util import assert_equal, connect_nodes, start_node, stop_node, sync_blocks
+import time
 
 class ElysiumSigmaReindexTest(ElysiumTestFramework):
     def run_test(self):
@@ -59,6 +60,7 @@ class ElysiumSigmaReindexTest(ElysiumTestFramework):
         connect_nodes(self.nodes[0], 1)
 
         sync_blocks(self.nodes)
+        time.sleep(1)
 
         reindexed_confirmed_mints = self.nodes[0].elysium_listmints()
         self.compare_mints(confirmed_mints, reindexed_confirmed_mints)


### PR DESCRIPTION
## PR intention
Fix the problem that block is created and add to the chain before reindex is done on reindexing test by adding deley.

## Code changes brief
- Add deley after sync block in test
