### PR TITLE
Fix ecdsa signature parsing in elysium

### DIFF
--- a/src/elysium/ecdsa_signature.cpp
+++ b/src/elysium/ecdsa_signature.cpp
@@ -17,27 +17,30 @@ ECDSASignature::ECDSASignature(secp256k1_ecdsa_signature const &sig)
 {
 }
 
-ECDSASignature ECDSASignature::Parse(ECDSAContext const &context, unsigned char const *signature, size_t len)
+ECDSASignature ECDSASignature::ParseCompact(ECDSAContext const &context, unsigned char const *signature, size_t len)
 {
     secp256k1_ecdsa_signature sig;
 
-    if (len >= 70 && len <= 72) {
-        if (1 != secp256k1_ecdsa_signature_parse_der(
-            context.Get(),
-            &sig,
-            signature,
-            len)) {
-            throw std::invalid_argument("DER Signature is invalid");
-        }
-    } else if (len == COMPACT_SIZE) {
-        if (1 != secp256k1_ecdsa_signature_parse_compact(
-            context.Get(),
-            &sig,
-            signature)) {
-            throw std::invalid_argument("Compact Signature is invalid");
-        }
-    } else {
-        throw std::invalid_argument("Signature encoding type is not supported");
+    if (1 != secp256k1_ecdsa_signature_parse_compact(
+        context.Get(),
+        &sig,
+        signature)) {
+        throw std::invalid_argument("Compact Signature is invalid");
+    }
+
+    return ECDSASignature(sig);
+}
+
+ECDSASignature ECDSASignature::ParseDER(ECDSAContext const &context, unsigned char const *signature, size_t len)
+{
+    secp256k1_ecdsa_signature sig;
+
+    if (1 != secp256k1_ecdsa_signature_parse_der(
+        context.Get(),
+        &sig,
+        signature,
+        len)) {
+        throw std::invalid_argument("DER Signature is invalid");
     }
 
     return ECDSASignature(sig);

--- a/src/elysium/ecdsa_signature.cpp
+++ b/src/elysium/ecdsa_signature.cpp
@@ -17,7 +17,7 @@ ECDSASignature::ECDSASignature(secp256k1_ecdsa_signature const &sig)
 {
 }
 
-ECDSASignature ECDSASignature::ParseCompact(ECDSAContext const &context, unsigned char const *signature, size_t len)
+ECDSASignature ECDSASignature::ParseCompact(ECDSAContext const &context, unsigned char const *signature)
 {
     secp256k1_ecdsa_signature sig;
 

--- a/src/elysium/ecdsa_signature.h
+++ b/src/elysium/ecdsa_signature.h
@@ -26,7 +26,7 @@ public:
     ECDSASignature(secp256k1_ecdsa_signature const &sig);
 
 public:
-    static ECDSASignature ParseCompact(ECDSAContext const &context, unsigned char const *signature, size_t len);
+    static ECDSASignature ParseCompact(ECDSAContext const &context, unsigned char const *signature);
     static ECDSASignature ParseDER(ECDSAContext const &context, unsigned char const *signature, size_t len);
 
 public:

--- a/src/elysium/ecdsa_signature.h
+++ b/src/elysium/ecdsa_signature.h
@@ -26,7 +26,8 @@ public:
     ECDSASignature(secp256k1_ecdsa_signature const &sig);
 
 public:
-    static ECDSASignature Parse(ECDSAContext const &context, unsigned char const *signature, size_t len);
+    static ECDSASignature ParseCompact(ECDSAContext const &context, unsigned char const *signature, size_t len);
+    static ECDSASignature ParseDER(ECDSAContext const &context, unsigned char const *signature, size_t len);
 
 public:
     std::vector<unsigned char> GetCompact(ECDSAContext const &context) const;

--- a/src/elysium/signaturebuilder.cpp
+++ b/src/elysium/signaturebuilder.cpp
@@ -46,7 +46,7 @@ ECDSASignature SigmaV1SignatureBuilder::Sign(CKey &key) const
         throw std::runtime_error("Fail to sign payload");
     }
 
-    return ECDSASignature::Parse(ECDSAContext::CreateSignContext(), sig.data(), sig.size());
+    return ECDSASignature::ParseDER(ECDSAContext::CreateSignContext(), sig.data(), sig.size());
 }
 
 bool SigmaV1SignatureBuilder::Verify(CPubKey const &pubKey, ECDSASignature const &signature) const

--- a/src/elysium/test/create_payload_tests.cpp
+++ b/src/elysium/test/create_payload_tests.cpp
@@ -590,7 +590,7 @@ BOOST_AUTO_TEST_CASE(payload_create_simple_spendv1)
     std::fill(publicKey.begin(), publicKey.end(), 0xFF);
     publicKey[0] = 0x02; // Compressed
 
-    auto signature = ECDSASignature::ParseCompact(ECDSAContext::CreateSignContext(), rawSignature.begin(), rawSignature.size());
+    auto signature = ECDSASignature::ParseCompact(ECDSAContext::CreateSignContext(), rawSignature.begin());
 
     key1.Generate();
     key2.Generate();

--- a/src/elysium/test/create_payload_tests.cpp
+++ b/src/elysium/test/create_payload_tests.cpp
@@ -590,7 +590,7 @@ BOOST_AUTO_TEST_CASE(payload_create_simple_spendv1)
     std::fill(publicKey.begin(), publicKey.end(), 0xFF);
     publicKey[0] = 0x02; // Compressed
 
-    auto signature = ECDSASignature::Parse(ECDSAContext::CreateSignContext(), rawSignature.begin(), rawSignature.size());
+    auto signature = ECDSASignature::ParseCompact(ECDSAContext::CreateSignContext(), rawSignature.begin(), rawSignature.size());
 
     key1.Generate();
     key2.Generate();

--- a/src/elysium/test/ecdsa_signature_tests.cpp
+++ b/src/elysium/test/ecdsa_signature_tests.cpp
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(construct_and_get_data)
 
 BOOST_AUTO_TEST_CASE(parse_signature)
 {
-    auto sig = ECDSASignature::ParseCompact(context, compact.data(), compact.size());
+    auto sig = ECDSASignature::ParseCompact(context, compact.data());
     auto derSig = ECDSASignature::ParseDER(context, rawSig.data(), rawSig.size());
     auto sigVec = sig.GetDER(context);
     auto derSigVec = derSig.GetDER(context);

--- a/src/elysium/test/ecdsa_signature_tests.cpp
+++ b/src/elysium/test/ecdsa_signature_tests.cpp
@@ -34,7 +34,7 @@ public:
 public:
     ECDSASignature GetSignature() const
     {
-        return ECDSASignature::Parse(context, rawSig.data(), rawSig.size());
+        return ECDSASignature::ParseDER(context, rawSig.data(), rawSig.size());
     }
 };
 
@@ -62,10 +62,12 @@ BOOST_AUTO_TEST_CASE(construct_and_get_data)
     BOOST_CHECK(sig.Valid());
 }
 
-BOOST_AUTO_TEST_CASE(parse_with64bytes)
+BOOST_AUTO_TEST_CASE(parse_signature)
 {
-    auto sig = ECDSASignature::Parse(context, compact.data(), compact.size());
+    auto sig = ECDSASignature::ParseCompact(context, compact.data(), compact.size());
+    auto derSig = ECDSASignature::ParseDER(context, rawSig.data(), rawSig.size());
     auto sigVec = sig.GetDER(context);
+    auto derSigVec = derSig.GetDER(context);
 
     std::vector<unsigned char> expected;
     expected.insert(expected.end(), rawSig.begin(), rawSig.end());
@@ -74,6 +76,9 @@ BOOST_AUTO_TEST_CASE(parse_with64bytes)
 
     BOOST_CHECK_EQUAL(expected, sigVec);
     BOOST_CHECK(sig.Valid());
+
+    BOOST_CHECK_EQUAL(expected, derSigVec);
+    BOOST_CHECK(derSig.Valid());
 }
 
 BOOST_AUTO_TEST_CASE(serialize)

--- a/src/elysium/test/signaturebuilder_sigmav1_tests.cpp
+++ b/src/elysium/test/signaturebuilder_sigmav1_tests.cpp
@@ -96,16 +96,16 @@ BOOST_AUTO_TEST_CASE(verify)
     auto validSig = ParseHex("181dad1d268f03d0a38beb34f6efa4ed12cbd6d00b62fc1d6094fa33746cdd0f73b3baa4d9cf699886fd448c0cd0ae7d1447e533fd6b5394f8f4fcd3c009de37");
     auto invalidSig = ParseHex("181dad1d268f03d0a38beb34f6efa4ed12cbd6d00b62fc1d6094fa33746cdd0f73b3baa4d9cf699886fd448c0cd0ae7d1447e533fd6b5394f8f4fcd3c009de38");
 
-    signature = ECDSASignature::ParseCompact(context, validSig.data(), validSig.size());
+    signature = ECDSASignature::ParseCompact(context, validSig.data());
     BOOST_CHECK_EQUAL(true, builder.Verify(publicKey, signature));
 
     // invalid signature
     builder = TestSignatureSigmaV1Builder(address, 10, proof);
-    signature = ECDSASignature::ParseCompact(context, invalidSig.data(), invalidSig.size());
+    signature = ECDSASignature::ParseCompact(context, invalidSig.data());
     BOOST_CHECK_EQUAL(false, builder.Verify(publicKey, signature));
 
     // invalid content
-    signature = ECDSASignature::ParseCompact(context, validSig.data(), validSig.size());
+    signature = ECDSASignature::ParseCompact(context, validSig.data());
     builder = TestSignatureSigmaV1Builder(CBitcoinAddress("aGXhTgKqDgdH9kHNTyg47TbwGfs54k2cQF"), 10, proof);
     BOOST_CHECK_EQUAL(false, builder.Verify(publicKey, signature));
 

--- a/src/elysium/test/signaturebuilder_sigmav1_tests.cpp
+++ b/src/elysium/test/signaturebuilder_sigmav1_tests.cpp
@@ -96,16 +96,16 @@ BOOST_AUTO_TEST_CASE(verify)
     auto validSig = ParseHex("181dad1d268f03d0a38beb34f6efa4ed12cbd6d00b62fc1d6094fa33746cdd0f73b3baa4d9cf699886fd448c0cd0ae7d1447e533fd6b5394f8f4fcd3c009de37");
     auto invalidSig = ParseHex("181dad1d268f03d0a38beb34f6efa4ed12cbd6d00b62fc1d6094fa33746cdd0f73b3baa4d9cf699886fd448c0cd0ae7d1447e533fd6b5394f8f4fcd3c009de38");
 
-    signature = ECDSASignature::Parse(context, validSig.data(), validSig.size());
+    signature = ECDSASignature::ParseCompact(context, validSig.data(), validSig.size());
     BOOST_CHECK_EQUAL(true, builder.Verify(publicKey, signature));
 
     // invalid signature
     builder = TestSignatureSigmaV1Builder(address, 10, proof);
-    signature = ECDSASignature::Parse(context, invalidSig.data(), invalidSig.size());
+    signature = ECDSASignature::ParseCompact(context, invalidSig.data(), invalidSig.size());
     BOOST_CHECK_EQUAL(false, builder.Verify(publicKey, signature));
 
     // invalid content
-    signature = ECDSASignature::Parse(context, validSig.data(), validSig.size());
+    signature = ECDSASignature::ParseCompact(context, validSig.data(), validSig.size());
     builder = TestSignatureSigmaV1Builder(CBitcoinAddress("aGXhTgKqDgdH9kHNTyg47TbwGfs54k2cQF"), 10, proof);
     BOOST_CHECK_EQUAL(false, builder.Verify(publicKey, signature));
 


### PR DESCRIPTION
## PR intention
Fix ecdsa signature parsing when produce signature which have size below 70 and not equal to size of compact signature.

## Code changes brief
- Allow user to choose type of raw ecdsa signature