### PR TITLE
fix test coverage generation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -189,7 +189,7 @@ test_bitcoin_filtered.info: test_bitcoin.info
 	$(LCOV) -r $< "/usr/include/*" -o $@
 
 rpc_test.info: test_bitcoin_filtered.info
-	-@TIMEOUT=15 python qa/pull-tester/rpc-tests.py $(EXTENDED_RPC_TESTS)
+	-@TIMEOUT=15 $(PYTHON) qa/pull-tester/rpc-tests.py $(EXTENDED_RPC_TESTS)
 	$(LCOV) -c -d $(abs_builddir)/src --t rpc-tests -o $@
 	$(LCOV) -z -d $(abs_builddir)/src
 	$(LCOV) -z -d $(abs_builddir)/src/leveldb

--- a/qa/rpc-tests/elysium_sendspend.py
+++ b/qa/rpc-tests/elysium_sendspend.py
@@ -2,6 +2,7 @@
 from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import ElysiumTestFramework
 from test_framework.util import assert_equal, assert_raises_message
+import time
 
 class ElysiumSendSpendTest(ElysiumTestFramework):
     def run_test(self):
@@ -94,6 +95,7 @@ class ElysiumSendSpendTest(ElysiumTestFramework):
         testing_node.elysium_sendmint(addr, sigmaProperty, {"0": 2})
         testing_node.generate(1)
         self.sync_all()
+        time.sleep(1)
 
         assert_raises_message(
             JSONRPCException,


### PR DESCRIPTION
## PR intention
when compiling with `--enable-lcov` and running `make cov`, a test coverage report is supposed to be generated in the root of the project. This fails in systems where the default python version is python 2, as the test script for `rpc-tests.py` is run with `python` - `rpc-tests.py` was changed some time ago to use python 3 syntax. So simply change this to use `$(PYTHON)`, where it will select one of the Python 3 versions available on the system.