### PR TITLE
Fix for assert during certain cases of invalidateblock

### DIFF
--- a/src/evo/evodb.cpp
+++ b/src/evo/evodb.cpp
@@ -39,3 +39,13 @@ void CEvoDB::WriteBestBlock(const uint256& hash)
 {
     Write(EVODB_BEST_BLOCK, hash);
 }
+
+void CEvoDB::CommitTransaction(CurTransaction & tx) {
+    LOCK(cs);
+    tx.Commit();
+}
+
+void CEvoDB::ClearTransaction(CurTransaction & tx) {
+    LOCK(cs);
+    tx.Clear();
+}

--- a/src/evo/evodb.h
+++ b/src/evo/evodb.h
@@ -21,7 +21,7 @@ private:
 
     typedef CDBTransaction<CDBWrapper, CDBBatch> RootTransaction;
     typedef CDBTransaction<RootTransaction, RootTransaction> CurTransaction;
-    typedef CScopedDBTransaction<RootTransaction, RootTransaction> ScopedTransaction;
+    typedef CScopedDBTransaction<RootTransaction, RootTransaction, CEvoDB> ScopedTransaction;
 
     CDBBatch rootBatch;
     RootTransaction rootDBTransaction;
@@ -33,7 +33,7 @@ public:
     std::unique_ptr<ScopedTransaction> BeginTransaction()
     {
         LOCK(cs);
-        auto t = ScopedTransaction::Begin(curDBTransaction);
+        auto t = ScopedTransaction::Begin(curDBTransaction, *this);
         return t;
     }
 
@@ -84,6 +84,9 @@ public:
 
     bool VerifyBestBlock(const uint256& hash);
     void WriteBestBlock(const uint256& hash);
+
+    void CommitTransaction(CurTransaction & tx);
+    void ClearTransaction(CurTransaction & tx);
 };
 
 extern CEvoDB* evoDb;


### PR DESCRIPTION
## PR intention
Sigma code bug might cause assert on block disconnect. This PR prevents this

## Code changes brief
`sigmaMintedPubCoins` field of `CBlockIndex` is accessed for read through `operator []` without checking if the specific entry being queried already exists. It is possible to code in `CSigmaState::RemoveBlock()` to incorrectly process this empty entry and fail with assert.

This PR ensures that zero sized entry of `sigmaMintedPubCoins` is handled correctly and prevents unnecessary creation of new entities of this type
