### PR TITLE
Removed block syncing in elysium reindex test

### DIFF
--- a/qa/rpc-tests/elysium_sigma_reindex.py
+++ b/qa/rpc-tests/elysium_sigma_reindex.py
@@ -54,13 +54,16 @@ class ElysiumSigmaReindexTest(ElysiumTestFramework):
         assert_equal(2, len(confirmed_mints))
         assert_equal(2, len(unconfirmed_mints))
 
+        blockcount = self.nodes[0].getblockcount()
+
         # restart with reindexing
         stop_node(self.nodes[0], 0)
         self.nodes[0] = start_node(0, self.options.tmpdir, ['-elysium', '-reindex'])
-        connect_nodes(self.nodes[0], 1)
 
-        sync_blocks(self.nodes)
-        time.sleep(1)
+        while self.nodes[0].getblockcount() < blockcount:
+            time.sleep(0.1)
+
+        connect_nodes(self.nodes[0], 1)
 
         reindexed_confirmed_mints = self.nodes[0].elysium_listmints()
         self.compare_mints(confirmed_mints, reindexed_confirmed_mints)
@@ -73,7 +76,6 @@ class ElysiumSigmaReindexTest(ElysiumTestFramework):
         self.nodes[0].elysium_sendspend(self.addrs[0], sigma_property, 1)
 
         self.nodes[0].generate(1)
-        sync_blocks(self.nodes)
 
         # all mints should be spend
         remaining_mints = self.nodes[0].elysium_listmints()


### PR DESCRIPTION
## PR intention
Fix test fails while trying to sync block by removing syncing logic because this test focuses on node state validation after reindexing.

## Code changes brief
- Update elysium_sigma_reindex.py to wait for node state to reach the destination block instead of sync with the whole network.
