### PR TITLE
Fix dev build with Qt 5.15 on MacOS

### DIFF
--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -6,6 +6,7 @@
 #include "clientmodel.h"
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QColor>
 #include <QTimer>
 


### PR DESCRIPTION
## PR intention
`master` build failing on MacOS in Qt: 
```
qt/trafficgraphwidget.cpp:53:13: error: member access into incomplete type 'QPainterPath'
        path.moveTo(x, YMARGIN + h);
            ^
/usr/local/Cellar/qt/5.15.0/lib/QtGui.framework/Headers/qmatrix.h:54:7: note: forward declaration of 'QPainterPath'
class QPainterPath;
      ^
qt/trafficgraphwidget.cpp:57:17: error: member access into incomplete type 'QPainterPath'
            path.lineTo(x, y);
                ^
/usr/local/Cellar/qt/5.15.0/lib/QtGui.framework/Headers/qmatrix.h:54:7: note: forward declaration of 'QPainterPath'
class QPainterPath;
      ^
qt/trafficgraphwidget.cpp:59:13: error: member access into incomplete type 'QPainterPath'
        path.lineTo(x, YMARGIN + h);
            ^
/usr/local/Cellar/qt/5.15.0/lib/QtGui.framework/Headers/qmatrix.h:54:7: note: forward declaration of 'QPainterPath'
class QPainterPath;
      ^
qt/trafficgraphwidget.cpp:106:22: error: variable has incomplete type 'QPainterPath'
        QPainterPath p;
                     ^
/usr/local/Cellar/qt/5.15.0/lib/QtGui.framework/Headers/qmatrix.h:54:7: note: forward declaration of 'QPainterPath'
class QPainterPath;
      ^
qt/trafficgraphwidget.cpp:113:22: error: variable has incomplete type 'QPainterPath'
        QPainterPath p;
                     ^
/usr/local/Cellar/qt/5.15.0/lib/QtGui.framework/Headers/qmatrix.h:54:7: note: forward declaration of 'QPainterPath'
class QPainterPath;
```

Appears related to latest release of Qt5.15 (https://github.com/Nheko-Reborn/nheko/commit/43d2ebc0958d364ff24ae70920a3edeef7d0ce72) . 
## Code changes brief
Just include `QPainterPath` in the file with the failure