### PR TITLE
Ban pre-0.14 nodes from network

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -21,7 +21,7 @@ static const int INIT_PROTO_VERSION = 90013;
 static const int GETHEADERS_VERSION = 90020;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 90026;
+static const int MIN_PEER_PROTO_VERSION = 90030;
 
 //! disconnect from all older peers after Znode payment HF
 static const int MIN_PEER_PROTO_VERSION_AFTER_ZNODE_PAYMENT_HF = 90026;


### PR DESCRIPTION
## PR intention
Do not accept connections with peers having version <0.14 to fix sync problems

## Code changes brief
Minimum protocol version changed from 90026 to 90030
