### PR TITLE
Fix dev build

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,12 +21,12 @@ else
 LDFLAGS_WRAP_EXCEPTIONS += -Wl,-wrap,__assert_fail
 endif
 endif
-endif
 
 if TARGET_WINDOWS
 BACKTRACE_LIB = -ldbghelp -lbacktrace
 else
 BACKTRACE_LIB = -lbacktrace
+endif
 endif
 
 if EMBEDDED_UNIVALUE
@@ -566,7 +566,6 @@ libbitcoin_consensus_a_SOURCES = \
   script/script_error.h \
   serialize.h \
   spork.h \
-  stacktraces.h \
   tinyformat.h \
   uint256.cpp \
   uint256.h \
@@ -643,7 +642,6 @@ libbitcoin_util_a_SOURCES = \
   fs.cpp \
   random.cpp \
   rpc/protocol.cpp \
-  stacktraces.cpp \
   support/cleanse.cpp \
   sync.cpp \
   threadinterrupt.cpp \
@@ -714,6 +712,11 @@ libsigma_a_SOURCES = \
 if GLIBC_BACK_COMPAT
 libbitcoin_util_a_SOURCES += compat/glibc_compat.cpp
 AM_LDFLAGS += $(COMPAT_LDFLAGS)
+endif
+
+if ENABLE_CRASH_HOOKS
+libbitcoin_util_a_SOURCES += stacktraces.cpp
+libbitcoin_consensus_a_SOURCES += stacktraces.h
 endif
 
 # cli: shared between zcoin-cli and zcoin-qt

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -12,9 +12,10 @@
 int
 main(int argc, char** argv)
 {
+#ifdef ENABLE_CRASH_HOOKS
     RegisterPrettySignalHandlers();
     RegisterPrettyTerminateHander();
-
+#endif
     ECC_Start();
     SetupEnvironment();
     fPrintToDebugLog = false; // don't want to write to debug.log file

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -79,10 +79,12 @@ static int AppInitRPC(int argc, char* argv[])
     //
     ParseParameters(argc, argv);
 
+#ifdef ENABLE_CRASH_HOOKS
     if (IsArgSet("-printcrashinfo")) {
         std::cout << GetCrashInfoStrFromSerializedStr(GetArg("-printcrashinfo", "")) << std::endl;
         return true;
     }
+#endif
 
     if (argc<2 || IsArgSet("-?") || IsArgSet("-h") || IsArgSet("-help") || IsArgSet("-version")) {
         std::string strUsage = strprintf(_("%s RPC client version"), _(PACKAGE_NAME)) + " " + FormatFullVersion() + "\n";
@@ -363,8 +365,10 @@ int CommandLineRPC(int argc, char *argv[])
 
 int main(int argc, char* argv[])
 {
+#ifdef ENABLE_CRASH_HOOKS
     RegisterPrettySignalHandlers();
     RegisterPrettyTerminateHander();
+#endif
 
     SetupEnvironment();
     if (!SetupNetworking()) {

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -43,10 +43,12 @@ static int AppInitRawTx(int argc, char* argv[])
     //
     ParseParameters(argc, argv);
 
+#ifdef ENABLE_CRASH_HOOKS
      if (IsArgSet("-printcrashinfo")) {
         std::cout << GetCrashInfoStrFromSerializedStr(GetArg("-printcrashinfo", "")) << std::endl;
         return true;
     }
+#endif
 
     // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
     try {
@@ -828,8 +830,10 @@ static int CommandLineRawTx(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
+#ifdef ENABLE_CRASH_HOOKS
     RegisterPrettyTerminateHander();
     RegisterPrettySignalHandlers();
+#endif
 
     SetupEnvironment();
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -76,11 +76,12 @@ bool AppInit(int argc, char* argv[])
     // If Qt is used, parameters/bitcoin.conf are parsed in qt/bitcoin.cpp's main()
     ParseParameters(argc, argv);
 
+#ifdef ENABLE_CRASH_HOOKS
      if (IsArgSet("-printcrashinfo")) {
         std::cout << GetCrashInfoStrFromSerializedStr(GetArg("-printcrashinfo", "")) << std::endl;
         return true;
     }
-
+#endif
     // Process help and version before taking care about datadir
     if (IsArgSet("-?") || IsArgSet("-h") ||  IsArgSet("-help") || IsArgSet("-version"))
     {
@@ -201,9 +202,10 @@ bool AppInit(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
+#ifdef ENABLE_CRASH_HOOKS
     RegisterPrettyTerminateHander();
     RegisterPrettySignalHandlers();
-    
+#endif    
     SetupEnvironment();
 
     // Connect bitcoind signal handlers

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -538,9 +538,10 @@ WId BitcoinApplication::getMainWinId() const
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char *argv[])
 {
+#ifdef ENABLE_CRASH_HOOKS
     RegisterPrettyTerminateHander();
     RegisterPrettySignalHandlers();
-    
+#endif    
     SetupEnvironment();
 
     /// 1. Parse command-line options. These take precedence over anything else.
@@ -591,12 +592,14 @@ int main(int argc, char *argv[])
     initTranslations(qtTranslatorBase, qtTranslator, translatorBase, translator);
     translationInterface.Translate.connect(Translate);
 
+#ifdef ENABLE_CRASH_HOOKS
     if (IsArgSet("-printcrashinfo")) {
         auto crashInfo = GetCrashInfoStrFromSerializedStr(GetArg("-printcrashinfo", ""));
         std::cout << crashInfo << std::endl;
         QMessageBox::critical(0, QObject::tr(PACKAGE_NAME), QString::fromStdString(crashInfo));
         return EXIT_SUCCESS;
     }
+#endif
 
     // Show help message immediately after parsing command-line options (for "-lang") and setting locale,
     // but before showing splash screen.

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -313,6 +313,7 @@ bool ShutdownRequested()
 }
 */
 
+#ifdef ENABLE_CRASH_HOOKS
 template<typename T>
 void translate_exception(const T &e)
 {
@@ -342,3 +343,4 @@ struct ExceptionInitializer {
 };
 
 BOOST_GLOBAL_FIXTURE( ExceptionInitializer );
+#endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -480,16 +480,20 @@ std::string HelpMessageOpt(const std::string &option, const std::string &message
            std::string("\n\n");
 }
 
+#ifdef ENABLE_CRASH_HOOKS
 static std::string FormatException(const std::exception_ptr pex, const char* pszThread)
 {
     return strprintf("EXCEPTION: %s", GetPrettyExceptionStr(pex));
 }
+#endif
 
 void PrintExceptionContinue(const std::exception_ptr pex, const char* pszThread)
 {
+#ifdef ENABLE_CRASH_HOOKS
     std::string message = FormatException(pex, pszThread);
     LogPrintf("\n\n************************\n%s\n", message);
     fprintf(stderr, "\n\n************************\n%s\n", message.c_str());
+#endif
 }
 
 boost::filesystem::path GetDefaultDataDir()


### PR DESCRIPTION
## PR intention
Development build failing following https://github.com/zcoinofficial/zcoin/pull/857. the Makefile includes `stacktraces.cpp/h` in all builds, which has a dependancy coming from `depends/` (`backtrace.h`). 

## Code changes brief
- Only include `stacktrace.cpp/h` if `--enable-crash-hooks` flag is used (only enabled for `depends/` build). 
- Add guards around functions from `stacktrace.cpp`