### PR TITLE
Force maxconnections to be at least DEFAULT_MAX_PEER_CONNECTIONS in evo znode mode

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -903,6 +903,18 @@ void InitParameterInteraction()
             LogPrintf("%s: parameter interaction: -whitebind set -> setting -listen=1\n", __func__);
     }
 
+    if (IsArgSet("-znodeblsprivkey")) {
+        // masternodes MUST accept connections from outside
+        ForceSetArg("-listen", "1");
+        LogPrintf("%s: parameter interaction: -znodeblsprivkey=... -> setting -listen=1\n", __func__);
+        if (GetArg("-maxconnections", DEFAULT_MAX_PEER_CONNECTIONS) < DEFAULT_MAX_PEER_CONNECTIONS) {
+            // masternodes MUST be able to handle at least DEFAULT_MAX_PEER_CONNECTIONS connections
+            ForceSetArg("-maxconnections", itostr(DEFAULT_MAX_PEER_CONNECTIONS));
+            LogPrintf("%s: parameter interaction: -znodeblsprivkey=... -> setting -maxconnections=%d instead of specified -maxconnections=%d\n",
+                    __func__, DEFAULT_MAX_PEER_CONNECTIONS, GetArg("-maxconnections", DEFAULT_MAX_PEER_CONNECTIONS));
+        }
+    }
+
     if (mapMultiArgs.count("-connect") && mapMultiArgs.at("-connect").size() > 0) {
         // when only connecting to trusted nodes, do not seed via DNS, or listen by default
         if (SoftSetBoolArg("-dnsseed", false))

--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -8,6 +8,7 @@
 #include "quorums_debug.h"
 #include "quorums_dkgsessionmgr.h"
 #include "quorums_utils.h"
+#include "quorums_init.h"
 
 #include "evo/specialtx.h"
 
@@ -119,7 +120,7 @@ bool CDKGSession::Init(const CBlockIndex* _pindexQuorum, const std::vector<CDete
         }
     }
 
-    if (!myProTxHash.IsNull()) {
+    if (!myProTxHash.IsNull() || GetBoolArg("-watchquorums", llmq::DEFAULT_WATCH_QUORUMS)) {
         quorumDKGDebugManager->InitLocalSessionStatus(params.type, pindexQuorum->GetBlockHash(), pindexQuorum->nHeight);
     }
 


### PR DESCRIPTION
## PR intention
Fix problem with forming quorums if znodes have inappropriately low `maxconnections` setting

## Code changes brief
Force `maxconnections` to be at least 125 if `znodeblsprivkey` is set. Also allow quorums to be watched by regular non-znode peers for debug purposes
