### PR TITLE
Add Qt button to zap wallet mints in settings

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -163,6 +163,16 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="reindexSigma">
+            <property name="toolTip">
+             <string>Restore all Sigma transactions following a reindex.</string>
+            </property>
+            <property name="text">
+             <string>&amp;Reindex Sigma</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -164,6 +164,7 @@ void OptionsDialog::setModel(OptionsModel *_model)
     connect(ui->threadsScriptVerif, SIGNAL(valueChanged(int)), this, SLOT(showRestartWarning()));
     /* Wallet */
     connect(ui->spendZeroConfChange, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
+    connect(ui->reindexSigma, SIGNAL(clicked(bool)), this, SLOT(handleEnabledZapChanged()));
     /* Network */
     connect(ui->allowIncoming, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
     connect(ui->connectSocks, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
@@ -182,6 +183,7 @@ void OptionsDialog::setMapper()
 
     /* Wallet */
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);
+    mapper->addMapping(ui->reindexSigma, OptionsModel::ReindexSigma);
     mapper->addMapping(ui->coinControlFeatures, OptionsModel::CoinControlFeatures);
 
     /* Network */
@@ -254,6 +256,23 @@ void OptionsDialog::on_hideTrayIcon_stateChanged(int fState)
     else
     {
         ui->minimizeToTray->setEnabled(true);
+    }
+}
+void OptionsDialog::handleEnabledZapChanged(){
+	QMessageBox msgBox;
+
+	if(ui->reindexSigma->isChecked()){
+        QMessageBox::StandardButton retval = QMessageBox::warning(this, tr("Confirm Reindex Sigma"),
+                     tr("Warning: On restart, this setting will wipe your transaction list, reindex the blockchain, and restore the list from the seed in your wallet. This will likely take a few hours. Are you sure?"),
+                     QMessageBox::Yes|QMessageBox::Cancel,
+                     QMessageBox::Cancel);
+        if(retval == QMessageBox::Cancel) {
+            ui->reindexSigma->setChecked(false);
+        }else {
+            showRestartWarning();
+        }
+    }else {
+        clearStatusLabel();
     }
 }
 

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -53,6 +53,7 @@ private Q_SLOTS:
     void on_hideTrayIcon_stateChanged(int fState);
 
     void showRestartWarning(bool fPersistent = false);
+    void handleEnabledZapChanged();
     void clearStatusLabel();
     void updateProxyValidationState();
     /* query the networks, for which the default proxy is used */

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -109,6 +109,15 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("bSpendZeroConfChange", true);
     if (!SoftSetBoolArg("-spendzeroconfchange", settings.value("bSpendZeroConfChange").toBool()))
         addOverriddenOption("-spendzeroconfchange");
+
+    if (!settings.contains("bReindexSigma"))
+        settings.setValue("bReindexSigma", DEFAULT_ZAP_WALLET);
+    if (!SoftSetBoolArg("-zapwalletmints", settings.value("bReindexSigma").toBool())) {
+        addOverriddenOption("-zapwalletmints");
+    } else {
+        settings.setValue("bReindexSigma", false);
+    }
+
 #endif
 
     // Network
@@ -240,6 +249,9 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
 #ifdef ENABLE_WALLET
         case SpendZeroConfChange:
             return settings.value("bSpendZeroConfChange");
+
+        case ReindexSigma:
+            return settings.value("bReindexSigma");
 #endif
         case DisplayUnit:
             return nDisplayUnit;
@@ -360,6 +372,13 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
         case SpendZeroConfChange:
             if (settings.value("bSpendZeroConfChange") != value) {
                 settings.setValue("bSpendZeroConfChange", value);
+                setRestartRequired(true);
+            }
+            break;
+
+        case ReindexSigma:
+            if (settings.value("bReindexSigma") != value) {
+                settings.setValue("bReindexSigma", value);
                 setRestartRequired(true);
             }
             break;

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -45,6 +45,7 @@ public:
         ThreadsScriptVerif,     // int
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
+        ReindexSigma,           // bool
         Listen,                 // bool
         TorSetup,               // bool
         OptionIDRowCount,

--- a/src/validation.h
+++ b/src/validation.h
@@ -146,6 +146,7 @@ static const bool DEFAULT_TIMESTAMPINDEX = false;
 static const bool DEFAULT_ADDRESSINDEX = false;
 static const bool DEFAULT_SPENTINDEX = false;
 static const bool DEFAULT_TOR_SETUP = false;
+static const bool DEFAULT_ZAP_WALLET = false;
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 
 /** Default for -mempoolreplacement */


### PR DESCRIPTION
## PR intention
Qt button in Preferences -> Wallet that sets `-zapwalletmints` (clear mints, clear transactions, reindex) in the daemon. conf setting is applied on a restart. Screens:

<img width="580" alt="Screenshot 2020-07-15 at 14 58 26" src="https://user-images.githubusercontent.com/6988731/87519517-eb714e00-c6ab-11ea-9d0d-718a2137aa78.png">
<img width="573" alt="Screenshot 2020-07-15 at 14 58 34" src="https://user-images.githubusercontent.com/6988731/87519525-edd3a800-c6ab-11ea-8bf4-69067f0029fe.png">
<img width="578" alt="Screenshot 2020-07-15 at 15 00 10" src="https://user-images.githubusercontent.com/6988731/87519533-f1ffc580-c6ab-11ea-92e8-13e980f49bba.png">

Warning is shown when clicked, "Cancel" unticks the box. Setting is reset after restart.

