### PR TITLE
Fix for deadlock when creating a transaction using Qt GUI with lots of inputs

### DIFF
--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -111,6 +111,10 @@ void MasternodeList::handleMasternodeListChanged()
 
 void MasternodeList::updateDIP3ListScheduled()
 {
+    TRY_LOCK(cs_main, fMainLocked);
+    if (!fMainLocked) return;
+    TRY_LOCK(walletModel->getWallet()->cs_wallet, fWalletLocked);
+    if (!fWalletLocked) return;
     TRY_LOCK(cs_dip3list, fLockAcquired);
     if (!fLockAcquired) return;
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -136,6 +136,8 @@ public:
     TransactionTableModel *getTransactionTableModel();
     RecentRequestsTableModel *getRecentRequestsTableModel();
 
+    CWallet *getWallet() const { return wallet; }
+
     CAmount getBalance(const CCoinControl *coinControl = NULL, bool fExcludeLocked = false) const;
     CAmount getUnconfirmedBalance() const;
     CAmount getImmatureBalance() const;


### PR DESCRIPTION
## PR intention
This is a fix for potential deadlock if some operation in Qt GUI takes at least few seconds to run and evo znode list is refreshed in background while the operation is still running

## Code changes brief
Additional locks are acquired to make sure no deadlock happens
