### PR TITLE
Update privacy by default feature

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -102,6 +102,7 @@ QT_FORMS_UI = \
   qt/forms/sigmacoincontroldialog.ui \
   qt/forms/askpassphrasedialog.ui \
   qt/forms/automintdialog.ui \
+  qt/forms/automintnotification.ui \
   qt/forms/coincontroldialog.ui \
   qt/forms/manualmintdialog.ui \
   qt/forms/editaddressdialog.ui \
@@ -136,6 +137,7 @@ QT_FORMS_UI = \
 QT_MOC_CPP = \
   qt/moc_addressbookpage.cpp \
   qt/moc_automintdialog.cpp \
+  qt/moc_automintnotification.cpp \
   qt/moc_zerocoinpage.cpp \
   qt/moc_sigmadialog.cpp \
   qt/moc_sigmacoincontroldialog.cpp \
@@ -201,7 +203,8 @@ QT_MOC_CPP = \
   qt/moc_lelantusmodel.cpp \
   qt/moc_lelantusdialog.cpp \
   qt/moc_lelantuscoincontroldialog.cpp \
-  qt/moc_automintmodel.cpp
+  qt/moc_automintmodel.cpp \
+  qt/moc_automintnotification.cpp
 
 BITCOIN_MM = \
   qt/macdockiconhandler.mm \
@@ -226,6 +229,7 @@ PROTOBUF_PROTO = qt/paymentrequest.proto
 BITCOIN_QT_H = \
   qt/addressbookpage.h \
   qt/automintdialog.h \
+  qt/automintnotification.h \
   qt/zerocoinpage.h \
   qt/sigmadialog.h \
   qt/sigmacoincontroldialog.h \
@@ -415,6 +419,7 @@ BITCOIN_QT_WINDOWS_CPP = qt/winshutdownmonitor.cpp
 BITCOIN_QT_WALLET_CPP = \
   qt/addressbookpage.cpp \
   qt/automintdialog.cpp \
+  qt/automintnotification.cpp \
   qt/zerocoinpage.cpp \
   qt/sigmadialog.cpp \
   qt/sigmacoincontroldialog.cpp \

--- a/src/qt/automintdialog.cpp
+++ b/src/qt/automintdialog.cpp
@@ -9,25 +9,21 @@
 #include <QPushButton>
 #include <QDebug>
 
-AutoMintDialog::AutoMintDialog(bool userAsk, QWidget *parent) :
+AutoMintDialog::AutoMintDialog(AutoMintMode mode, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::AutoMintDialog),
     model(0),
     lelantusModel(0),
     requiredPassphase(true),
-    userAsk(userAsk),
-    minting(false)
+    minting(false),
+    mode(mode)
 {
     ENTER_CRITICAL_SECTION(cs_main);
     ENTER_CRITICAL_SECTION(pwalletMain->cs_wallet);
 
     ui->setupUi(this);
     ui->buttonBox->button(QDialogButtonBox::Ok)->setText("Anonymize");
-    ui->buttonBox->button(QDialogButtonBox::Cancel)->setText("Ask me later");
-
-    if (userAsk) {
-        ui->warningLabel->setVisible(false);
-    }
+    ui->buttonBox->button(QDialogButtonBox::Cancel)->setText("Cancel");
 }
 
 AutoMintDialog::~AutoMintDialog()
@@ -56,8 +52,6 @@ void AutoMintDialog::accept()
         }
     }
 
-    ui->warningLabel->setVisible(false);
-    ui->warningLabel->setVisible(false);
     ui->buttonBox->setVisible(false);
     ui->passEdit->setVisible(false);
     ui->passLabel->setVisible(false);
@@ -117,19 +111,11 @@ void AutoMintDialog::setModel(WalletModel *model)
 
     ENTER_CRITICAL_SECTION(lelantusModel->cs);
 
-    if (userAsk) {
-        ui->lockWarningLabel->setText(QString("Unlock your wallet to anonymize all transparent funds."));
-    }
-
     if (this->model->getEncryptionStatus() != WalletModel::Locked) {
         ui->passLabel->setVisible(false);
         ui->passEdit->setVisible(false);
         ui->lockCheckBox->setVisible(false);
-
-        ui->lockWarningLabel->setText(
-            userAsk
-            ? QString("Do you want to anonymize all transparent funds?")
-            : QString("Do you want to anonymize these funds?"));
+        ui->lockWarningLabel->setText(QString("Do you want to anonymize all transparent funds?"));
 
         requiredPassphase = false;
     }

--- a/src/qt/automintdialog.cpp
+++ b/src/qt/automintdialog.cpp
@@ -56,7 +56,7 @@ void AutoMintDialog::accept()
 
         if (!lelantusModel->unlockWallet(passphase, lock ? 0 : 60 * 1000)) {
             QDialog::accept();
-            lelantusModel->ackMintAll(AutoMintAck::FailToUnlock);
+            lelantusModel->sendAckMintAll(AutoMintAck::FailToUnlock);
             return;
         }
     }
@@ -78,14 +78,14 @@ void AutoMintDialog::accept()
 
     QDialog::accept();
 
-    lelantusModel->ackMintAll(status, minted, error);
+    lelantusModel->sendAckMintAll(status, minted, error);
 }
 
 int AutoMintDialog::exec()
 {
     ensureLelantusModel();
     if (lelantusModel->getMintableAmount() <= 0) {
-        lelantusModel->ackMintAll(AutoMintAck::NotEnoughFund);
+        lelantusModel->sendAckMintAll(AutoMintAck::NotEnoughFund);
         return 0;
     }
 
@@ -95,7 +95,7 @@ int AutoMintDialog::exec()
 void AutoMintDialog::reject()
 {
     ensureLelantusModel();
-    lelantusModel->ackMintAll(AutoMintAck::UserReject);
+    lelantusModel->sendAckMintAll(AutoMintAck::UserReject);
     QDialog::reject();
 }
 

--- a/src/qt/automintdialog.h
+++ b/src/qt/automintdialog.h
@@ -7,6 +7,11 @@
 #include <QPainter>
 #include <QPaintEvent>
 
+enum class AutoMintMode : uint8_t {
+    MintAll, // come from overview page
+    AutoMintAll // come from notification
+};
+
 namespace Ui {
     class AutoMintDialog;
 }
@@ -16,7 +21,7 @@ class AutoMintDialog : public QDialog
     Q_OBJECT;
 
 public:
-    explicit AutoMintDialog(bool userAsk, QWidget *parent = 0);
+    explicit AutoMintDialog(AutoMintMode mode, QWidget *parent = 0);
     ~AutoMintDialog();
 
 public:
@@ -34,8 +39,8 @@ private:
     WalletModel *model;
     LelantusModel *lelantusModel;
     bool requiredPassphase;
-    bool userAsk;
     bool minting;
+    AutoMintMode mode;
 
     void ensureLelantusModel();
 };

--- a/src/qt/automintdialog.h
+++ b/src/qt/automintdialog.h
@@ -35,11 +35,17 @@ private Q_SLOTS:
     void reject();
 
 private:
+    enum class AutoMintProgress : uint8_t {
+        Start,
+        Unlocking,
+        Minting
+    };
+
     Ui::AutoMintDialog *ui;
     WalletModel *model;
     LelantusModel *lelantusModel;
     bool requiredPassphase;
-    bool minting;
+    AutoMintProgress progress;
     AutoMintMode mode;
 
     void ensureLelantusModel();

--- a/src/qt/automintmodel.h
+++ b/src/qt/automintmodel.h
@@ -6,6 +6,8 @@
 #include "../uint256.h"
 #include "../validation.h"
 
+#include "automintdialog.h"
+
 #include <QDateTime>
 #include <QObject>
 #include <QTimer>
@@ -18,10 +20,12 @@ enum class AutoMintState : uint8_t {
     Disabled,
     WaitingIncomingFund,
     WaitingUserToActivate,
-    WaitingForUserResponse
+    WaitingForUserResponse,
+    Anonymizing
 };
 
 enum class AutoMintAck : uint8_t {
+    AskToMint,
     Success,
     WaitUserToActive,
     FailToMint,
@@ -75,7 +79,6 @@ public:
 
 public:
     bool askingUser() const;
-    void userAskToMint();
 
 public Q_SLOTS:
     void ackMintAll(AutoMintAck ack, CAmount minted, QString error);

--- a/src/qt/automintmodel.h
+++ b/src/qt/automintmodel.h
@@ -84,9 +84,6 @@ public Q_SLOTS:
     void ackMintAll(AutoMintAck ack, CAmount minted, QString error);
     void checkAutoMint(bool force = false);
 
-    void resetSyncing();
-    void setSyncing();
-
     void startAutoMint();
 
     void updateAutoMintOption(bool);
@@ -98,9 +95,6 @@ Q_SIGNALS:
     void closeAutomintNotification();
 
 private:
-    void subscribeToCoreSignals();
-    void unsubscribeFromCoreSignals();
-
     void processAutoMintAck(AutoMintAck ack, CAmount minted, QString error);
 
 private:
@@ -110,10 +104,7 @@ private:
 
     AutoMintState autoMintState;
 
-    QTimer *resetSyncingTimer;
     QTimer *autoMintCheckTimer;
-
-    std::atomic<bool> syncing;
 
     IncomingFundNotifier *notifier;
 };

--- a/src/qt/automintmodel.h
+++ b/src/qt/automintmodel.h
@@ -20,7 +20,6 @@ enum class AutoMintState : uint8_t {
     Disabled,
     WaitingIncomingFund,
     WaitingUserToActivate,
-    WaitingForUserResponse,
     Anonymizing
 };
 
@@ -78,7 +77,7 @@ public:
     ~AutoMintModel();
 
 public:
-    bool askingUser() const;
+    bool isAnonymizing() const;
 
 public Q_SLOTS:
     void ackMintAll(AutoMintAck ack, CAmount minted, QString error);

--- a/src/qt/automintmodel.h
+++ b/src/qt/automintmodel.h
@@ -30,7 +30,8 @@ enum class AutoMintAck : uint8_t {
     FailToMint,
     NotEnoughFund,
     UserReject,
-    FailToUnlock
+    FailToUnlock,
+    Close
 };
 
 class IncomingFundNotifier : public QObject
@@ -92,6 +93,9 @@ public Q_SLOTS:
 
 Q_SIGNALS:
     void message(const QString &title, const QString &message, unsigned int style);
+
+    void requireShowAutomintNotification();
+    void closeAutomintNotification();
 
 private:
     void subscribeToCoreSignals();

--- a/src/qt/automintnotification.cpp
+++ b/src/qt/automintnotification.cpp
@@ -19,8 +19,11 @@ AutomintNotification::AutomintNotification(QWidget *parent) :
 AutomintNotification::~AutomintNotification()
 {
     if (lelantusModel) {
-        disconnect(this, SIGNAL(ackMintAll(AutoMintAck, CAmount, QString)),
-            lelantusModel, SLOT(ackMintAll(AutoMintAck, CAmount, QString)));
+        auto automintModel = lelantusModel->getAutoMintModel();
+        if (automintModel) {
+            disconnect(this, SIGNAL(ackMintAll(AutoMintAck, CAmount, QString)),
+                automintModel, SLOT(ackMintAll(AutoMintAck, CAmount, QString)));
+        }
     }
 
     delete ui;
@@ -31,10 +34,17 @@ void AutomintNotification::setModel(WalletModel *model)
     if (model) {
         lelantusModel = model->getLelantusModel();
 
-        if (lelantusModel) {
-            connect(this, SIGNAL(ackMintAll(AutoMintAck, CAmount, QString)),
-                lelantusModel, SLOT(ackMintAll(AutoMintAck, CAmount, QString)));
+        if (!lelantusModel) {
+            return;
         }
+
+        auto automintModel = lelantusModel->getAutoMintModel();
+        if (!automintModel) {
+            return;
+        }
+
+        connect(this, SIGNAL(ackMintAll(AutoMintAck, CAmount, QString)),
+            automintModel, SLOT(ackMintAll(AutoMintAck, CAmount, QString)));
     }
 }
 

--- a/src/qt/automintnotification.cpp
+++ b/src/qt/automintnotification.cpp
@@ -1,0 +1,57 @@
+#include "automintnotification.h"
+#include "automintmodel.h"
+
+#include "ui_automintnotification.h"
+
+#include <QPushButton>
+
+AutomintNotification::AutomintNotification(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::AutomintNotification)
+{
+    ui->setupUi(this);
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setText("Anonymize");
+    ui->buttonBox->button(QDialogButtonBox::Cancel)->setText("Dismiss");
+
+    setWindowFlags(windowFlags() | Qt::FramelessWindowHint);
+}
+
+AutomintNotification::~AutomintNotification()
+{
+    if (lelantusModel) {
+        disconnect(this, SIGNAL(ackMintAll(AutoMintAck, CAmount, QString)),
+            lelantusModel, SLOT(ackMintAll(AutoMintAck, CAmount, QString)));
+    }
+
+    delete ui;
+}
+
+void AutomintNotification::setModel(WalletModel *model)
+{
+    if (model) {
+        lelantusModel = model->getLelantusModel();
+
+        if (lelantusModel) {
+            connect(this, SIGNAL(ackMintAll(AutoMintAck, CAmount, QString)),
+                lelantusModel, SLOT(ackMintAll(AutoMintAck, CAmount, QString)));
+        }
+    }
+}
+
+bool AutomintNotification::close()
+{
+    Q_EMIT ackMintAll(AutoMintAck::NotEnoughFund, 0, QString());
+    QDialog::close();
+}
+
+void AutomintNotification::accept()
+{
+    Q_EMIT ackMintAll(AutoMintAck::AskToMint, 0, QString());
+    QDialog::accept();
+}
+
+void AutomintNotification::reject()
+{
+    Q_EMIT ackMintAll(AutoMintAck::UserReject, 0, QString());
+    QDialog::reject();
+}

--- a/src/qt/automintnotification.cpp
+++ b/src/qt/automintnotification.cpp
@@ -41,7 +41,7 @@ void AutomintNotification::setModel(WalletModel *model)
 bool AutomintNotification::close()
 {
     Q_EMIT ackMintAll(AutoMintAck::NotEnoughFund, 0, QString());
-    QDialog::close();
+    return QDialog::close();
 }
 
 void AutomintNotification::accept()

--- a/src/qt/automintnotification.h
+++ b/src/qt/automintnotification.h
@@ -23,7 +23,6 @@ public:
 
 Q_SIGNALS:
     void ackMintAll(AutoMintAck, CAmount, QString);
-    void requireMintAll();
 
 public Q_SLOTS:
     bool close();

--- a/src/qt/automintnotification.h
+++ b/src/qt/automintnotification.h
@@ -1,0 +1,40 @@
+#ifndef ZCOIN_QT_AUTOMINTNOTIFICATION_H
+#define ZCOIN_QT_AUTOMINTNOTIFICATION_H
+
+#include "lelantusmodel.h"
+#include "walletmodel.h"
+
+#include <QDialog>
+
+namespace Ui {
+    class AutomintNotification;
+}
+
+class AutomintNotification : public QDialog
+{
+    Q_OBJECT;
+
+public:
+    explicit AutomintNotification(QWidget *parent = 0);
+    ~AutomintNotification();
+
+public:
+    void setModel(WalletModel *model);
+
+Q_SIGNALS:
+    void ackMintAll(AutoMintAck, CAmount, QString);
+    void requireMintAll();
+
+public Q_SLOTS:
+    bool close();
+
+private Q_SLOTS:
+    void accept();
+    void reject();
+
+private:
+    Ui::AutomintNotification *ui;
+    LelantusModel *lelantusModel;
+};
+
+#endif // ZCOIN_QT_AUTOMINTNOTIFICATION_H

--- a/src/qt/forms/automintdialog.ui
+++ b/src/qt/forms/automintdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>598</width>
-    <height>231</height>
+    <height>252</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -30,22 +30,9 @@
     <enum>QLayout::SetMinimumSize</enum>
    </property>
    <item>
-    <widget class="QLabel" name="warningLabel">
-     <property name="text">
-      <string notr="true">You have incoming transaction(s)!</string>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::RichText</enum>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QLabel" name="lockWarningLabel">
      <property name="text">
-      <string>Unlock your wallet to anonymize these funds.</string>
+      <string>Unlock your wallet to anonymize all transparent funds.</string>
      </property>
     </widget>
    </item>

--- a/src/qt/forms/automintnotification.ui
+++ b/src/qt/forms/automintnotification.ui
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AutomintNotification</class>
+ <widget class="QDialog" name="AutomintNotification">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>373</width>
+    <height>170</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Anonymize Funds</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
+   <item>
+    <widget class="QLabel" name="warningLabel">
+     <property name="text">
+      <string notr="true">You have incoming transaction(s)!</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="lockWarningLabel">
+     <property name="text">
+      <string>Do you want to anonymize all transparent funds?</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>30</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>AutomintNotification</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>AutomintNotification</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/qt/lelantusmodel.cpp
+++ b/src/qt/lelantusmodel.cpp
@@ -19,10 +19,16 @@ LelantusModel::LelantusModel(
     wallet(wallet)
 {
     autoMintModel = new AutoMintModel(this, optionsModel, wallet, this);
+
+    connect(this, SIGNAL(ackMintAll(AutoMintAck, CAmount, QString)),
+        autoMintModel, SLOT(ackMintAll(AutoMintAck, CAmount, QString)));
 }
 
 LelantusModel::~LelantusModel()
 {
+    disconnect(this, SIGNAL(ackMintAll(AutoMintAck, CAmount, QString)),
+        autoMintModel, SLOT(ackMintAll(AutoMintAck, CAmount, QString)));
+
     delete autoMintModel;
 
     autoMintModel = nullptr;
@@ -156,17 +162,9 @@ void LelantusModel::mintAll(AutoMintMode mode)
     Q_EMIT askMintAll(mode);
 }
 
-void LelantusModel::notifyUserToMint()
+void LelantusModel::sendAckMintAll(AutoMintAck ack, CAmount minted, QString error)
 {
-    Q_EMIT notifyAutomint();
-}
-
-void LelantusModel::ackMintAll(AutoMintAck ack, CAmount minted, QString error)
-{
-    autoMintModel->ackMintAll(ack, minted, error);
-    if (ack == AutoMintAck::AskToMint) {
-        mintAll(AutoMintMode::AutoMintAll);
-    }
+    Q_EMIT ackMintAll(ack, minted, error);
 }
 
 void LelantusModel::lock()

--- a/src/qt/lelantusmodel.cpp
+++ b/src/qt/lelantusmodel.cpp
@@ -28,11 +28,6 @@ LelantusModel::~LelantusModel()
     autoMintModel = nullptr;
 }
 
-void LelantusModel::askToMint()
-{
-    autoMintModel->userAskToMint();
-}
-
 CAmount LelantusModel::getMintableAmount()
 {
     std::vector<std::pair<CAmount, std::vector<COutput>>> valueAndUTXO;
@@ -156,14 +151,22 @@ CAmount LelantusModel::mintAll()
     return s;
 }
 
-void LelantusModel::askUserToMint(bool userAsk)
+void LelantusModel::mintAll(AutoMintMode mode)
 {
-    Q_EMIT askMintAll(userAsk);
+    Q_EMIT askMintAll(mode);
+}
+
+void LelantusModel::notifyUserToMint()
+{
+    Q_EMIT notifyAutomint();
 }
 
 void LelantusModel::ackMintAll(AutoMintAck ack, CAmount minted, QString error)
 {
     autoMintModel->ackMintAll(ack, minted, error);
+    if (ack == AutoMintAck::AskToMint) {
+        mintAll(AutoMintMode::AutoMintAll);
+    }
 }
 
 void LelantusModel::lock()

--- a/src/qt/lelantusmodel.cpp
+++ b/src/qt/lelantusmodel.cpp
@@ -172,7 +172,7 @@ void LelantusModel::ackMintAll(AutoMintAck ack, CAmount minted, QString error)
 void LelantusModel::lock()
 {
     LOCK2(wallet->cs_wallet, cs);
-    if (autoMintModel->askingUser()) {
+    if (autoMintModel->isAnonymizing()) {
         QTimer::singleShot(MODEL_UPDATE_DELAY, this, SLOT(lock()));
         return;
     }

--- a/src/qt/lelantusmodel.h
+++ b/src/qt/lelantusmodel.h
@@ -1,6 +1,7 @@
 #ifndef ZCOIN_QT_LELANTUSMODEL_H
 #define ZCOIN_QT_LELANTUSMODEL_H
 
+#include "automintdialog.h"
 #include "automintmodel.h"
 #include "platformstyle.h"
 #include "optionsmodel.h"
@@ -23,7 +24,6 @@ public:
     ~LelantusModel();
 
 public:
-    void askToMint();
     CAmount getMintableAmount();
     AutoMintModel* getAutoMintModel();
 
@@ -35,16 +35,19 @@ public:
 
     CAmount mintAll();
 
-    void ackMintAll(AutoMintAck ack, CAmount minted = 0, QString error = QString(""));
-
 public:
     mutable CCriticalSection cs;
 
 Q_SIGNALS:
-    void askMintAll(bool userAsk);
+    void askMintAll(AutoMintMode);
+    void notifyAutomint();
 
 public Q_SLOTS:
-    void askUserToMint(bool userAsk = false);
+    void ackMintAll(AutoMintAck ack, CAmount minted = 0, QString error = QString(""));
+
+    void mintAll(AutoMintMode);
+    void notifyUserToMint();
+
     void lock();
 
 private:

--- a/src/qt/lelantusmodel.h
+++ b/src/qt/lelantusmodel.h
@@ -35,19 +35,17 @@ public:
 
     CAmount mintAll();
 
+    void sendAckMintAll(AutoMintAck ack, CAmount minted = 0, QString error = QString());
+
 public:
     mutable CCriticalSection cs;
 
 Q_SIGNALS:
     void askMintAll(AutoMintMode);
-    void notifyAutomint();
+    void ackMintAll(AutoMintAck ack, CAmount minted, QString error);
 
 public Q_SLOTS:
-    void ackMintAll(AutoMintAck ack, CAmount minted = 0, QString error = QString(""));
-
     void mintAll(AutoMintMode);
-    void notifyUserToMint();
-
     void lock();
 
 private:

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -210,7 +210,7 @@ void OverviewPage::on_anonymizeButton_clicked()
         return;
     }
 
-    lelantusModel->askToMint();
+    lelantusModel->mintAll(AutoMintMode::MintAll);
 }
 
 void OverviewPage::setBalance(

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -59,6 +59,9 @@ bool WalletFrame::addWallet(const QString& name, WalletModel *walletModel)
 
     connect(walletView, SIGNAL(outOfSyncWarningClicked()), this, SLOT(outOfSyncWarningClicked()));
 
+    // Ensure walletview is able to response to resize and move events
+    gui->installEventFilter(walletView);
+
     return true;
 }
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -686,6 +686,8 @@ void WalletView::showAutomintNotification()
         return;
     }
 
+    automintNotification->setWindowFlags(automintNotification->windowFlags() | Qt::FramelessWindowHint);
+
     QRect rect(this->mapToGlobal(QPoint(0, 0)), this->size());
     auto pos = QStyle::alignedRect(
         Qt::LeftToRight,
@@ -693,10 +695,8 @@ void WalletView::showAutomintNotification()
         automintNotification->size(),
         rect).topLeft();
 
-    pos.setX(pos.x() - 10);
-    pos.setY(pos.y() + 18);
-
-    automintNotification->setWindowFlags(automintNotification->windowFlags() | Qt::FramelessWindowHint);
+    pos.setX(pos.x() - 8);
+    pos.setY(pos.y() + automintNotification->style()->pixelMetric(QStyle::PM_TitleBarHeight));
     automintNotification->move(pos);
 
     automintNotification->show();
@@ -713,10 +713,8 @@ void WalletView::repositionAutomintNotification()
             automintNotification->size(),
             rect).topLeft();
 
-        pos.setX(pos.x() - 10);
-        pos.setY(pos.y() + 18);
-
-        automintNotification->setWindowFlags(automintNotification->windowFlags() | Qt::FramelessWindowHint);
+        pos.setX(pos.x() - 8);
+        pos.setY(pos.y() + automintNotification->style()->pixelMetric(QStyle::PM_TitleBarHeight));
         automintNotification->move(pos);
     }
 }

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -707,7 +707,7 @@ void WalletView::checkMintableAmount(CAmount, CAmount, CAmount, CAmount, CAmount
 
 void WalletView::askMintAll(AutoMintMode mode)
 {
-    automintNotification->close();
+    automintNotification->setVisible(false);
 
     if (!walletModel) {
         return;

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -201,6 +201,9 @@ public Q_SLOTS:
     void checkMintableAmount(
         CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount anonymizableBalance);
 
+    /** Close automint notification */
+    void closeAutomintNotification();
+
     /** Ask user to do auto mint */
     void askMintAll(AutoMintMode mode);
 

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -78,6 +78,8 @@ public:
 
     void showOutOfSyncWarning(bool fShow);
 
+    bool eventFilter(QObject *watched, QEvent *event);
+
 private:
     void setupTransactionPage();
     void setupSendCoinPage();
@@ -196,6 +198,9 @@ public Q_SLOTS:
 
     /** Show automint notification */
     void showAutomintNotification();
+
+    /** Re-position automint notification */
+    void repositionAutomintNotification();
 
     /** Check mintable amount to close automint notification */
     void checkMintableAmount(

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -9,6 +9,8 @@
 #include "../config/bitcoin-config.h"
 #endif
 
+#include "automintdialog.h"
+#include "automintnotification.h"
 #include "amount.h"
 #include "masternodelist.h"
 #include "sigmadialog.h"
@@ -123,6 +125,8 @@ private:
     QProgressDialog *progressDialog;
     const PlatformStyle *platformStyle;
 
+    AutomintNotification *automintNotification;
+
 public Q_SLOTS:
     /** Switch to overview (home) page */
     void gotoOverviewPage();
@@ -190,8 +194,15 @@ public Q_SLOTS:
     /** User has requested more information about the out of sync state */
     void requestedSyncWarningInfo();
 
+    /** Show automint notification */
+    void showAutomintNotification();
+
+    /** Check mintable amount to close automint notification */
+    void checkMintableAmount(
+        CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount anonymizableBalance);
+
     /** Ask user to do auto mint */
-    void askMintAll(bool userAsk);
+    void askMintAll(AutoMintMode mode);
 
 Q_SIGNALS:
     /** Signal that we want to show the main window */


### PR DESCRIPTION
## PR intention
Update privacy by default feature by notifying users to mint all instead of show dialog and block usage.

## Code changes brief
- Create auto mint notification design file and create a class to use it
- Update and refactor Lelantus model and automint model
- Update logic to detect new funds to avoiding show notification when detected znode funds
- Update walletview class to show notification when found signals from automint model

If detect mintable funds on startup or found incoming funds, notification should be shown
![atm-notification](https://user-images.githubusercontent.com/23252700/94856029-9a2a5c80-0459-11eb-8224-fdd41c725d61.png)

If users click anonymize `Anonymize Funds` dialog should be shown
1) if wallet is not encrypted
![atm-uen](https://user-images.githubusercontent.com/23252700/94856138-bdeda280-0459-11eb-96a6-6db38f3822ae.png)

or 2) if wallet is encrypted. (require wallet passphase to do the operation)
![atm-enc](https://user-images.githubusercontent.com/23252700/94856165-c514b080-0459-11eb-9a81-a779ead59de6.png)

and progress message would be shown
![atm-progress-unlocking](https://user-images.githubusercontent.com/23252700/94856234-e2e21580-0459-11eb-9fa0-716a1b51ac15.png)

![atm-progress-anonymizing](https://user-images.githubusercontent.com/23252700/94856245-e5dd0600-0459-11eb-86ea-4659556e7e98.png)