### PR TITLE
Fixing the invalidate block issue

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -391,6 +391,26 @@ public:
         // Bip39
         consensus.nMnemonicBlock = 222400;
     }
+    virtual bool SkipUndoForBlock(int nHeight) const
+    {
+        return nHeight == 293526;
+    }
+    virtual bool ApplyUndoForTxout(int nHeight, uint256 const & txid, int n) const
+    {
+        // We only apply first 23 tx inputs UNDOs for the tx 7702 in block 293526
+        if (!SkipUndoForBlock(nHeight)) {
+            return true;
+        }
+        static std::map<uint256, int> const txs = { {uint256S("7702eaa0e042846d39d01eeb4c87f774913022e9958cfd714c5c2942af380569"), 22} };
+        std::map<uint256, int>::const_iterator const itx = txs.find(txid);
+        if (itx == txs.end()) {
+            return false;
+        }
+        if (n <= itx->second) {
+            return true;
+        }
+        return false;
+    }
 };
 
 static CMainParams mainParams;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -94,6 +94,8 @@ public:
 	int nModulusV1StopBlock;
 
     const ChainTxData& TxData() const { return chainTxData; }
+    virtual bool SkipUndoForBlock(int /*nHeight*/) const { return false; }
+    virtual bool ApplyUndoForTxout(int /*nHeight*/, uint256 const & /*txid*/, int /*n*/) const { return true; }
 protected:
     CChainParams() {}
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2117,9 +2117,11 @@ static DisconnectResult DisconnectBlock(const CBlock& block, CValidationState& s
             }
             for (unsigned int j = tx.vin.size(); j-- > 0;) {
                 const COutPoint &out = tx.vin[j].prevout;
-                int res = ApplyTxInUndo(std::move(txundo.vprevout[j]), view, out);
-                if (res == DISCONNECT_FAILED) return DISCONNECT_FAILED;
-                fClean = fClean && res != DISCONNECT_UNCLEAN;
+                if (Params().ApplyUndoForTxout(pindex->nHeight, tx.GetHash(), j)) {
+                    int res = ApplyTxInUndo(std::move(txundo.vprevout[j]), view, out);
+                    if (res == DISCONNECT_FAILED) return DISCONNECT_FAILED;
+                    fClean = fClean && res != DISCONNECT_UNCLEAN;
+                }
             }
             // At this point, all of txundo.vprevout should have been moved out.
         }
@@ -2162,6 +2164,10 @@ static DisconnectResult DisconnectBlock(const CBlock& block, CValidationState& s
     */
 
     evoDb->WriteBestBlock(pindex->pprev->GetBlockHash());
+
+    if(Params().SkipUndoForBlock(pindex->nHeight)) {
+        fClean = true;
+    }
 
     if (pfClean)
         *pfClean = fClean;


### PR DESCRIPTION
## PR intention
The PR solves the zcoind crash when invalidating blocks beyond 293526. The block 293526 introduced several empty records to the block undo information. On invalidating, this empty information caused 
1. A crash when zcoind was started and current BH was so that 293526 appeared in a startup block unwind check
2. A termination when zcoind was invalidating the block 293526 with invalidateblock RPC call

## Code changes brief
Restoring of undo information for the block 293526 was skipped for the txs which have the empty undo information
