### PR TITLE
Implement correct abandon for lelantus and sigma mints

### DIFF
--- a/src/qt/sigmadialog.cpp
+++ b/src/qt/sigmadialog.cpp
@@ -520,6 +520,7 @@ void SigmaDialog::updateAvailableToMintBalance(const CAmount& balance)
 void SigmaDialog::updateMintableBalance()
 {
     updateAvailableToMintBalance(this->walletModel->getBalance(NULL, true));
+    walletModel->checkSigmaAmount(true);
 }
 
 // Coin Control: copy label "Quantity" to clipboard


### PR DESCRIPTION
## PR intention
During reorg it was possible that some mints become orphaned (e.g. block got disconnected and mint was a child of its coinbase transaction). Mint transaction would never be confirmed and it results in inflated "Pending" private balance. This PR allows you to abandon transaction in question restoring normal pending balance.

## Code changes brief
Implementation of mint archival when transaction is abandoned
