### PR TITLE
Fix Linux include fcntl.h

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -32,7 +32,7 @@
 #include <windows.h>
 #include <ws2tcpip.h>
 #else
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/select.h>
 #include <sys/socket.h>


### PR DESCRIPTION
## PR intention
Fixes a compilation warning on Alpine Linux (and presumably on some other OSes)

## Code changes brief
Including <fcntl.h> instead of <sys/fcntl.h>
https://github.com/bitcoin/bitcoin/commit/648bdc8cc09c85748967b86347bbc7825e339d5f
